### PR TITLE
[codex] set up Ghost CMS Docker deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+GHOST_URL=https://blog.dohyeon.kr
+GHOST_PORT=2368
+
+# SQLite only works as a local/development Ghost setup. Move to MySQL 8 before
+# treating this as a production Ghost install.
+GHOST_NODE_ENV=development
+GHOST_CONTENT_DIR=./content
+
+# Direct mail is enough for initial setup, but configure SMTP before relying on
+# invitations, password resets, or member email.
+GHOST_MAIL_TRANSPORT=Direct

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Release & Deploy Astro
+name: Release & Deploy Ghost
 
 on:
   push:
@@ -11,13 +11,11 @@ jobs:
     runs-on: self-hosted
 
     steps:
-      # 1️⃣ 코드 체크아웃
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # semantic-release 필수
+          fetch-depth: 0
 
-      # 2️⃣ Node 설정
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -28,14 +26,9 @@ jobs:
           corepack enable
           corepack prepare pnpm@10 --activate
 
-      # 4️⃣ 의존성 설치
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install server dependencies
-        run: pnpm --dir server install --frozen-lockfile
-
-      # 6️⃣ semantic-release 실행
       - name: Semantic Release
         id: semrel
         env:
@@ -43,85 +36,41 @@ jobs:
         run: |
           pnpm semantic-release || echo "NO_RELEASE=true" >> $GITHUB_ENV
 
-      # 6️⃣-1 semantic-release가 릴리즈하지 않았을 때 버전 설정 (최신 태그 또는 package.json)
-      - name: Set version for build
+      - name: Prepare remote directories
         run: |
-          if [ -z "${RELEASE_VERSION:-}" ]; then
-            VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || node -p "JSON.parse(require('fs').readFileSync('package.json','utf8')).version")
-            echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
-          fi
+          ssh dohyeon.kr 'mkdir -p /var/www/ghost-blog/content /var/www/ghost-blog/secrets'
 
-      # 7️⃣ Astro 빌드
-      - name: Build Astro
-        run: pnpm build
-
-      - name: Build server
-        run: pnpm --dir server build
-
-      # 8️⃣ 배포 (예시: rsync)
-      - name: Deploy Astro
+      - name: Ensure SOPS tools are available
         run: |
-          rsync -avz --delete \
-            dist/ \
-            /var/www/astro-app/
+          ssh dohyeon.kr 'set -euo pipefail; if ! command -v age >/dev/null 2>&1; then sudo apt-get update && sudo apt-get install -y age; fi; if ! command -v sops >/dev/null 2>&1; then tmp=$(mktemp); curl -fsSL -o "$tmp" https://github.com/getsops/sops/releases/download/v3.13.1/sops-v3.13.1.linux.amd64; sudo install -m 0755 "$tmp" /usr/local/bin/sops; rm -f "$tmp"; fi; test -f "$HOME/.config/sops/age/keys.txt"'
 
-      - name: Deploy server
+      - name: Deploy Ghost compose files
         run: |
-          mkdir -p /var/www/astro-app/server
-          rsync -avz --delete \
-            --exclude 'node_modules/' \
-            --exclude 'data/' \
-            server/ \
-            /var/www/astro-app/server/
+          rsync -avz \
+            docker-compose.yml \
+            .env.example \
+            deploy/nginx/blog.dohyeon.kr.conf \
+            dohyeon.kr:/var/www/ghost-blog/
+          rsync -avz \
+            secrets/ghost.env.enc \
+            dohyeon.kr:/var/www/ghost-blog/secrets/
 
-      - name: Install production server deps
+      - name: Decrypt remote env file
         run: |
-          set -euo pipefail
-          export NVM_DIR="$HOME/.nvm"
-          # shellcheck disable=SC1090
-          source "$NVM_DIR/nvm.sh"
-          nvm use 24
+          ssh dohyeon.kr 'cd /var/www/ghost-blog && SOPS_AGE_KEY_FILE="$HOME/.config/sops/age/keys.txt" sops -d --input-type dotenv --output-type dotenv secrets/ghost.env.enc > .env && chmod 600 .env'
 
-          corepack enable
-          corepack prepare pnpm@10 --activate
-
-          cd /var/www/astro-app/server
-          pnpm install --prod --frozen-lockfile
-
-      - name: Restart server via pm2
+      - name: Start Ghost with Docker Compose
         run: |
-          set -euo pipefail
+          ssh dohyeon.kr 'cd /var/www/ghost-blog && docker compose pull && docker compose up -d'
 
-          export NVM_DIR="$HOME/.nvm"
-          # shellcheck disable=SC1090
-          source "$NVM_DIR/nvm.sh"
+      - name: Disable legacy Astro Nginx config
+        run: |
+          ssh dohyeon.kr 'if [ -f /etc/nginx/conf.d/astro.conf ]; then sudo mv /etc/nginx/conf.d/astro.conf /etc/nginx/conf.d/astro.conf.disabled; fi'
 
-          cd /var/www/astro-app/server
+      - name: Apply Nginx config
+        run: |
+          ssh dohyeon.kr 'sudo cp /var/www/ghost-blog/blog.dohyeon.kr.conf /etc/nginx/sites-available/blog.dohyeon.kr && sudo ln -sf /etc/nginx/sites-available/blog.dohyeon.kr /etc/nginx/sites-enabled/blog.dohyeon.kr && sudo nginx -t && sudo systemctl reload nginx'
 
-          # ecosystem.config.cjs 파일 생성 (server/package.json의 type=module 영향 회피)
-          cat > ecosystem.config.cjs << 'EOF'
-          module.exports = {
-            apps: [
-              {
-                name: 'dohyeon-kr-server',
-                script: 'pnpm',
-                args: 'run start',
-                env: {
-                  NODE_ENV: 'production',
-                  HOST: '127.0.0.1',
-                  PORT: '3020',
-                  // 배포 디렉토리(/var/www/...) 밖에 DB를 두어 빌드/rsync로 초기화되는 문제를 방지
-                  DB_PATH: '/var/lib/dohyeon-kr/visits.sqlite',
-                },
-              },
-            ],
-          };
-          EOF
-
-          # DB 디렉토리 보장(영구 저장소)
-          sudo mkdir -p /var/lib/dohyeon-kr
-          sudo chown -R "$(whoami)":"$(id -gn)" /var/lib/dohyeon-kr
-
-          pm2 startOrReload ecosystem.config.cjs
-          pm2 save
-          pm2 status
+      - name: Show Ghost status
+        run: |
+          ssh dohyeon.kr 'cd /var/www/ghost-blog && docker compose ps'

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@ pnpm-debug.log*
 .env
 .env.production
 
+# Ghost persistent content volume
+content/
+
+# Plaintext secret files. Commit only SOPS-encrypted *.env.enc files.
+secrets/*.env
+
 # macOS-specific files
 .DS_Store
 

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,5 @@
+creation_rules:
+  - path_regex: ^secrets/.*\.env\.enc$
+    input_type: dotenv
+    output_type: dotenv
+    age: age1lcgsswm7ycfpnlwyul6yh4g84l6lwhmwzehu5sxfhs06vdnjusxqma938u

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -2,4 +2,6 @@ creation_rules:
   - path_regex: ^secrets/.*\.env\.enc$
     input_type: dotenv
     output_type: dotenv
-    age: age1lcgsswm7ycfpnlwyul6yh4g84l6lwhmwzehu5sxfhs06vdnjusxqma938u
+    age: >-
+      age1lcgsswm7ycfpnlwyul6yh4g84l6lwhmwzehu5sxfhs06vdnjusxqma938u,
+      age1tqhqpn77enh2nskt7flkzah8eanmtsg2m7ef3wvm2gkul30h7ausf2mhy2

--- a/README.md
+++ b/README.md
@@ -1,88 +1,141 @@
-# Astro Starter Kit: Blog
+# dohyeon.kr Ghost CMS
+
+This repository now deploys Ghost CMS for `https://blog.dohyeon.kr`.
+`https://dohyeon.kr` redirects to the Ghost site.
+
+The previous Astro source is still in the repository for reference and content
+migration, but the active deployment path is Docker Compose + Ghost.
+
+## Stack
+
+- Ghost 5 Docker image
+- SQLite content database for the initial setup
+- Nginx reverse proxy on `blog.dohyeon.kr`
+- Nginx redirect from `dohyeon.kr` to `blog.dohyeon.kr`
+- GitHub Actions deploying to `ssh dohyeon.kr`
+
+## Local Run
 
 ```sh
-pnpm create astro@latest -- --template blog
+cp .env.example .env
+docker compose up -d
 ```
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+Ghost will be available at:
 
-Features:
+- Site: `http://localhost:2368`
+- Admin: `http://localhost:2368/ghost`
 
-- ✅ Minimal styling (make it your own!)
-- ✅ 100/100 Lighthouse performance
-- ✅ SEO-friendly with canonical URLs and OpenGraph data
-- ✅ Sitemap support
-- ✅ RSS Feed support
-- ✅ Markdown & MDX support
+## Server Layout
 
-## 🚀 Project Structure
-
-Inside of your Astro project, you'll see the following folders and files:
+The GitHub Actions workflow deploys these files to `/var/www/ghost-blog` on the
+`dohyeon.kr` server:
 
 ```text
-├── public/
-├── src/
-│   ├── components/
-│   ├── content/
-│   ├── layouts/
-│   └── pages/
-├── astro.config.mjs
-├── README.md
-├── package.json
-└── tsconfig.json
+/var/www/ghost-blog/
+├── docker-compose.yml
+├── .env
+├── .env.example
+├── blog.dohyeon.kr.conf
+├── secrets/
+│   └── ghost.env.enc
+└── content/
 ```
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+`content/` is the persistent Ghost volume. It contains uploaded images, themes,
+logs, and the SQLite database at `content/data/ghost.db`.
 
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
+## Secrets
 
-The `src/content/` directory contains "collections" of related Markdown and MDX documents. Use `getCollection()` to retrieve posts from `src/content/blog/`, and type-check your frontmatter using an optional schema. See [Astro's Content Collections docs](https://docs.astro.build/en/guides/content-collections/) to learn more.
+Secrets are managed with SOPS + age.
 
-Any static assets, like images, can be placed in the `public/` directory.
+Committed files:
 
-## 🧞 Commands
+```text
+.sops.yaml
+secrets/ghost.env.enc
+```
 
-All commands are run from the root of the project, from a terminal:
+Plaintext secret files are ignored by git:
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `pnpm install`             | Installs dependencies                            |
-| `pnpm dev`             | Starts local dev server at `localhost:4321`      |
-| `pnpm build`           | Build your production site to `./dist/`          |
-| `pnpm preview`         | Preview your build locally, before deploying     |
-| `pnpm astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `pnpm astro -- --help` | Get help using the Astro CLI                     |
+```text
+secrets/*.env
+.env
+```
 
-## Footer 방문 통계(Today/Total)
+The current server has its age private key at:
 
-이 프로젝트는 Astro SSG를 유지하면서, 별도 Fastify 서버(`server/`) + SQLite로 방문 통계를 집계해 푸터에 표시합니다.
+```text
+~/.config/sops/age/keys.txt
+```
 
-### 로컬 개발 실행
+To edit Ghost environment values from a machine that has the age private key,
+decrypt to an ignored file, edit, then re-encrypt:
 
-- 백엔드(터미널 1):
-  - `pnpm --dir server install`
-  - `pnpm --dir server dev` (기본 `http://127.0.0.1:3000`)
-- 프론트(터미널 2):
-  - `pnpm install`
-  - `pnpm dev`
+```sh
+sops -d --input-type dotenv --output-type dotenv secrets/ghost.env.enc > secrets/ghost.env
+sops --encrypt --input-type dotenv --output-type dotenv --filename-override secrets/ghost.env.enc --output secrets/ghost.env.enc secrets/ghost.env
+```
 
-Astro dev 서버는 `astro.config.mjs`의 proxy 설정으로 `/api/*` 요청을 백엔드로 프록시합니다.
+To apply the encrypted env manually on the server:
 
-### 서버 환경변수(선택)
+```sh
+ssh dohyeon.kr 'cd /var/www/ghost-blog && SOPS_AGE_KEY_FILE="$HOME/.config/sops/age/keys.txt" sops -d --input-type dotenv --output-type dotenv secrets/ghost.env.enc > .env && chmod 600 .env'
+```
 
-- `DB_PATH`: SQLite 파일 경로 (기본: `server/data/visits.sqlite`)
-- `PORT`: 서버 포트 (기본: `3000`)
-- `HOST`: 바인딩 호스트 (기본: `127.0.0.1`)
+## Deployment
 
-### 배포(EC2) 요약
+Push to `main` or run the `Release & Deploy Ghost` workflow manually.
 
-- Nginx(또는 Caddy)에서 `/api/`는 Fastify로 프록시, 그 외는 `dist/` 정적 파일 서빙
-- 서버는 systemd 또는 pm2로 상시 실행
+The workflow:
 
-## 👀 Want to learn more?
+1. runs semantic-release
+2. creates `/var/www/ghost-blog/content` on `dohyeon.kr`
+3. ensures `sops` and `age` are available on the server
+4. uploads `docker-compose.yml`, `.env.example`, the encrypted env, and the Nginx sample config
+5. decrypts `secrets/ghost.env.enc` to `/var/www/ghost-blog/.env`
+6. runs `docker compose pull && docker compose up -d`
+7. disables the legacy Astro Nginx vhost
+8. applies the Ghost Nginx vhost and reloads Nginx
 
-Check out [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+Useful server commands:
 
-## Credit
+```sh
+ssh dohyeon.kr 'cd /var/www/ghost-blog && docker compose ps'
+ssh dohyeon.kr 'cd /var/www/ghost-blog && docker compose logs -f ghost'
+ssh dohyeon.kr 'cd /var/www/ghost-blog && docker compose pull && docker compose up -d'
+```
 
-This theme is based off of the lovely [Bear Blog](https://github.com/HermanMartinus/bearblog/).
+## Nginx
+
+The sample config is in `deploy/nginx/blog.dohyeon.kr.conf`. The current server
+already has a Let's Encrypt certificate at
+`/etc/letsencrypt/live/blog.dohyeon.kr`.
+
+Apply it on the server:
+
+```sh
+ssh dohyeon.kr 'sudo cp /var/www/ghost-blog/blog.dohyeon.kr.conf /etc/nginx/sites-available/blog.dohyeon.kr'
+ssh dohyeon.kr 'sudo ln -sf /etc/nginx/sites-available/blog.dohyeon.kr /etc/nginx/sites-enabled/blog.dohyeon.kr'
+ssh dohyeon.kr 'sudo nginx -t && sudo systemctl reload nginx'
+```
+
+If rebuilding this on a fresh server, issue a certificate after DNS for
+`blog.dohyeon.kr` points to the server:
+
+```sh
+ssh dohyeon.kr 'sudo certbot --nginx -d blog.dohyeon.kr'
+```
+
+## SQLite Note
+
+This setup intentionally uses SQLite for the first Ghost install:
+
+```env
+GHOST_NODE_ENV=development
+database__client=sqlite3
+```
+
+Ghost's supported production database is MySQL 8. Before treating this as a real
+production blog, migrate the compose file to MySQL 8 and set
+`GHOST_NODE_ENV=production`.

--- a/deploy/nginx/blog.dohyeon.kr.conf
+++ b/deploy/nginx/blog.dohyeon.kr.conf
@@ -1,0 +1,50 @@
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name blog.dohyeon.kr dohyeon.kr;
+
+    return 301 https://blog.dohyeon.kr$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name dohyeon.kr;
+
+    ssl_certificate /etc/letsencrypt/live/blog.dohyeon.kr/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/blog.dohyeon.kr/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    return 301 https://blog.dohyeon.kr$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+
+    server_name blog.dohyeon.kr;
+
+    client_max_body_size 50m;
+
+    ssl_certificate /etc/letsencrypt/live/blog.dohyeon.kr/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/blog.dohyeon.kr/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location / {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        proxy_pass http://127.0.0.1:2368;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  ghost:
+    image: ghost:5-alpine
+    container_name: dohyeon-ghost
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:${GHOST_PORT:-2368}:2368"
+    environment:
+      url: ${GHOST_URL:-https://blog.dohyeon.kr}
+      NODE_ENV: ${GHOST_NODE_ENV:-development}
+      database__client: sqlite3
+      database__connection__filename: /var/lib/ghost/content/data/ghost.db
+      server__host: 0.0.0.0
+      server__port: 2368
+      mail__transport: ${GHOST_MAIL_TRANSPORT:-Direct}
+      logging__transports: '["stdout"]'
+    volumes:
+      - ${GHOST_CONTENT_DIR:-./content}:/var/lib/ghost/content

--- a/secrets/ghost.env.enc
+++ b/secrets/ghost.env.enc
@@ -1,0 +1,15 @@
+GHOST_URL=ENC[AES256_GCM,data:Xu4Xudm6xVvGpgC4bEJGts6SoLwgYeg=,iv:RQCeWbHFy73ZCC7YW5YQCGiM4NIIJWrusgRyy1Tbg/M=,tag:1a4hFQjKR0zgVFF73WorxQ==,type:str]
+GHOST_PORT=ENC[AES256_GCM,data:ak7zTQ==,iv:djtRrDgCgHM/XdEYJnez3PqROCkjgYjJlCjHGxDAzWc=,tag:CGMP07GwfP8LcNCClgvusg==,type:str]
+#ENC[AES256_GCM,data:FLb91h2B0yTlDBXagj4GAOsdMJvbLMeUOLhDbOUFp5xost6exH8hzUTbRFqLGCh/1KnuN4teTgagfB5tG3yp5Zd59XlttPgZizbA80g=,iv:z/LLhzlU1pwyE38jwfPHuCVeuyNZnly5Q6OCZUsuyM8=,tag:UjseoIsxiMDG7T0mT6S0ww==,type:comment]
+#ENC[AES256_GCM,data:KX3lfWpL8np6iAmv3i0O/cFW5EfAsWsYEGFk5nyjgkkiOva8f/76xMkkFgXV,iv:9JCNT7vJAqfSV7lGZSA+2AED0FAM0Xzd4IAabzfFjV4=,tag:aFx5pxpN28Sbc+8eJTSwog==,type:comment]
+GHOST_NODE_ENV=ENC[AES256_GCM,data:VyAGzS+mLF2Rcco=,iv:aexWGVnnSaa2mCKgbkDeZVWXTzt/W2povul+6LcltLI=,tag:WqRcFqvi9mJwyohSkCZSjw==,type:str]
+GHOST_CONTENT_DIR=ENC[AES256_GCM,data:YFojbrB2vZFK,iv:Bgdk2clqttMl8/57/MEYH0IR1but4KnB7yxLz1jMTtE=,tag:Prr9pjUTELq2zNp85sRE9Q==,type:str]
+#ENC[AES256_GCM,data:Mv4UrAkVthB22AqUx3kYIRb/3S4cqH5yZBtKdaNbURH40mV+Vd+Z2BvYr0IugXVfQDwfMF9S7naqVyVeFzEHMKbPEwEAr707KhCCEzZp,iv:y8KTqybNLg/FjFSBo+D9HP/jMaVeVxsXFC3UB2CtGH8=,tag:1ry2CZ/DdGpRfUfffSNw2w==,type:comment]
+#ENC[AES256_GCM,data:UG42fZ1ATxtlgB5FbMAZS2eBnBlAKRfQ9LJ1RjVrDRwRFrDAXcObKqoo1hhdnVA=,iv:HHZxcxvIa7z1Chihunnuk/Q3/YQR99p9zcEO3S/qYmU=,tag:aZenUEc+vKwJJ2bc0tudHw==,type:comment]
+GHOST_MAIL_TRANSPORT=ENC[AES256_GCM,data:cNqpTKQc,iv:ce8Rxd7DgXuWOQPV0DHo5uEgGeBmHyOlUvYWKRmTymM=,tag:4Y+qzYoe+DYrk+1pNaiA5g==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHOWVtNUNxR2wvbjVhUWwx\nU2pGeDRVay9ITVlOV0hMQUtrUGtQR3BNZ0IwCkpuMkZTN2VlNDNxTGtmL3VNdlU4\nbmJNSnhnVGxBbGJyT2VMaENYM0UzZmsKLS0tIDZVWHpnM3kwZXFaN1d3c1JZVElW\nbGcxLzUxZEpqdjZZanZwdUIvb092dUUKTQM74Ek4SwM2c7dkX8qPHibQF0Ztphe5\njjmkoW3wUW9++AUyfaXDXGcpdwq/39HHQZwup2SX4gp+F8yzXUKkHA==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age1lcgsswm7ycfpnlwyul6yh4g84l6lwhmwzehu5sxfhs06vdnjusxqma938u
+sops_lastmodified=2026-06-07T15:16:22Z
+sops_mac=ENC[AES256_GCM,data:C2Iq0Djv2RiJYP4oPtB3FQ0utKUPNqrpeHtJIwcO7uyuANFgnnL3C14UjQCJPfEsceFkJP399Og8klA+TEaBeN2G0S8l4rn5YYqxBZ4kdTd0TRWEsZJvV2oI11L3g+pRCPtU/zgbR5ycbLpXax0ZRbfLZly7H7kNGhdOVGcHdr0=,iv:nu3jW03eUcGwKbKGo9UItCzrC9F+RgyyNOznSMm8ec4=,tag:QOM9DGaPcCjZGQQTMtK5mQ==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.1

--- a/secrets/ghost.env.enc
+++ b/secrets/ghost.env.enc
@@ -1,15 +1,15 @@
-GHOST_URL=ENC[AES256_GCM,data:Xu4Xudm6xVvGpgC4bEJGts6SoLwgYeg=,iv:RQCeWbHFy73ZCC7YW5YQCGiM4NIIJWrusgRyy1Tbg/M=,tag:1a4hFQjKR0zgVFF73WorxQ==,type:str]
-GHOST_PORT=ENC[AES256_GCM,data:ak7zTQ==,iv:djtRrDgCgHM/XdEYJnez3PqROCkjgYjJlCjHGxDAzWc=,tag:CGMP07GwfP8LcNCClgvusg==,type:str]
-#ENC[AES256_GCM,data:FLb91h2B0yTlDBXagj4GAOsdMJvbLMeUOLhDbOUFp5xost6exH8hzUTbRFqLGCh/1KnuN4teTgagfB5tG3yp5Zd59XlttPgZizbA80g=,iv:z/LLhzlU1pwyE38jwfPHuCVeuyNZnly5Q6OCZUsuyM8=,tag:UjseoIsxiMDG7T0mT6S0ww==,type:comment]
-#ENC[AES256_GCM,data:KX3lfWpL8np6iAmv3i0O/cFW5EfAsWsYEGFk5nyjgkkiOva8f/76xMkkFgXV,iv:9JCNT7vJAqfSV7lGZSA+2AED0FAM0Xzd4IAabzfFjV4=,tag:aFx5pxpN28Sbc+8eJTSwog==,type:comment]
-GHOST_NODE_ENV=ENC[AES256_GCM,data:VyAGzS+mLF2Rcco=,iv:aexWGVnnSaa2mCKgbkDeZVWXTzt/W2povul+6LcltLI=,tag:WqRcFqvi9mJwyohSkCZSjw==,type:str]
-GHOST_CONTENT_DIR=ENC[AES256_GCM,data:YFojbrB2vZFK,iv:Bgdk2clqttMl8/57/MEYH0IR1but4KnB7yxLz1jMTtE=,tag:Prr9pjUTELq2zNp85sRE9Q==,type:str]
-#ENC[AES256_GCM,data:Mv4UrAkVthB22AqUx3kYIRb/3S4cqH5yZBtKdaNbURH40mV+Vd+Z2BvYr0IugXVfQDwfMF9S7naqVyVeFzEHMKbPEwEAr707KhCCEzZp,iv:y8KTqybNLg/FjFSBo+D9HP/jMaVeVxsXFC3UB2CtGH8=,tag:1ry2CZ/DdGpRfUfffSNw2w==,type:comment]
-#ENC[AES256_GCM,data:UG42fZ1ATxtlgB5FbMAZS2eBnBlAKRfQ9LJ1RjVrDRwRFrDAXcObKqoo1hhdnVA=,iv:HHZxcxvIa7z1Chihunnuk/Q3/YQR99p9zcEO3S/qYmU=,tag:aZenUEc+vKwJJ2bc0tudHw==,type:comment]
-GHOST_MAIL_TRANSPORT=ENC[AES256_GCM,data:cNqpTKQc,iv:ce8Rxd7DgXuWOQPV0DHo5uEgGeBmHyOlUvYWKRmTymM=,tag:4Y+qzYoe+DYrk+1pNaiA5g==,type:str]
-sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHOWVtNUNxR2wvbjVhUWwx\nU2pGeDRVay9ITVlOV0hMQUtrUGtQR3BNZ0IwCkpuMkZTN2VlNDNxTGtmL3VNdlU4\nbmJNSnhnVGxBbGJyT2VMaENYM0UzZmsKLS0tIDZVWHpnM3kwZXFaN1d3c1JZVElW\nbGcxLzUxZEpqdjZZanZwdUIvb092dUUKTQM74Ek4SwM2c7dkX8qPHibQF0Ztphe5\njjmkoW3wUW9++AUyfaXDXGcpdwq/39HHQZwup2SX4gp+F8yzXUKkHA==\n-----END AGE ENCRYPTED FILE-----\n
+GHOST_URL=ENC[AES256_GCM,data:k1BIyxctaY2LhsQUw+7tR64A5nvHOms=,iv:FNIf5IgtnyMFcHyS05b1ZmrU1n48XKf7GFe6xyU9QyE=,tag:WVxvhPAsHj/KgY7n+Tu31g==,type:str]
+GHOST_PORT=ENC[AES256_GCM,data:568gdg==,iv:dczyaRHMBRvCr9yvWlQ+2DjYj7UiDERD5uiapeLahqA=,tag:uC1t9IGSKwk4LEqjojhdkg==,type:str]
+#ENC[AES256_GCM,data:HA7wenPpOldjXeDWAZK6U7abE9Iauqhi9p908Im/wDRGA1QqELi2yY9FMAXONT4ZNhqlTaRT5YPmDpFoPQ4FHotG8eszWuz4ZTJ/wp0=,iv:F8gsv/zINBJ+Kr5moj4Din/kjdXuYOXCy5czpq/YNIw=,tag:1JdSzq7DnUJ6XBymOk5c6A==,type:comment]
+#ENC[AES256_GCM,data:w7AQnlqvo+k0RuNTIKsl531m1AQIT5mmHkrnFQ9+OwMm76gOzFdIW4Z0E5m0,iv:lxlVHJ9JBCseTASe7LqUOvDY/A/uLvwiOuvL+kpO+ao=,tag:8wX3Q0HdHceGjGvWlByr5Q==,type:comment]
+GHOST_NODE_ENV=ENC[AES256_GCM,data:amTJxCQLK3SRvZo=,iv:8Fe6sqPbkjz9NJB90NWKwqQ72fSevFTq2d264IRqcFw=,tag:kPXEhchXkf1YanOpomnZ8Q==,type:str]
+GHOST_CONTENT_DIR=ENC[AES256_GCM,data:+bYmiVjyY5u1,iv:VGjbr7NwJ1iftXnUf+xCaxAMFbQmSO5DiqCmPFWUmF4=,tag:DHPd7FEvbFWnlAUOE1H8tg==,type:str]
+#ENC[AES256_GCM,data:tHDZAL8dSwgdL9dRh9+ju7RdO8aw36TSHXr9PoCRP2CFN4p482v5asVBHuVj0kKlW5CKchQ4lTS4+2EJwrhv3eGWGIyd745LxJE8MMzq,iv:eltPW+enYdC6Dq8chqLOtQz5+O5KqdmvLNzfta4pGWQ=,tag:yILos73Bm94uVE/pn+/KVg==,type:comment]
+#ENC[AES256_GCM,data:vdTn6gpGAWGqnxIANo/ocUS7VTU5710M+AB6MQnybBEYynRiu9WPtd0Q9kmnMKc=,iv:UeqxR9+UIu9OhOGRfoIFRj3XXiDS8IIx3JhLkEiD4Kc=,tag:qcak057rGqdR3xnW2K3IqA==,type:comment]
+GHOST_MAIL_TRANSPORT=ENC[AES256_GCM,data:Z3EeoxIF,iv:1XqoWVK56AFt8ZfTx89FuZlHwvYOK7HzdzQ/+ejkZ/A=,tag:kp844DOefU/hakwQ50d3vw==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxKy9leW9ta3pOM2wyeFMr\nRElZZm5rcENJbnErcm84K1EzTm9mRHhyQVJRCkFGS2hLTEhxT0U5Q2RpVkQyM0Ur\nSWltNVJpdU1QTlVqc3FWWnNIMEFqbFUKLS0tIFpyN2x3bjY0d01QUno5dmFISTZO\nTitSMFhkbnh5SHNxdk5MaGVNMi9tbmsKXNVxN91dPAw5BvBVD7tuCFJuSNjLBznB\njRqtZfjTSN6auRW1xBCyJyS3uFHmayGWm+Hv/OUIsSQwoHMYd+wLBA==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1lcgsswm7ycfpnlwyul6yh4g84l6lwhmwzehu5sxfhs06vdnjusxqma938u
-sops_lastmodified=2026-06-07T15:16:22Z
-sops_mac=ENC[AES256_GCM,data:C2Iq0Djv2RiJYP4oPtB3FQ0utKUPNqrpeHtJIwcO7uyuANFgnnL3C14UjQCJPfEsceFkJP399Og8klA+TEaBeN2G0S8l4rn5YYqxBZ4kdTd0TRWEsZJvV2oI11L3g+pRCPtU/zgbR5ycbLpXax0ZRbfLZly7H7kNGhdOVGcHdr0=,iv:nu3jW03eUcGwKbKGo9UItCzrC9F+RgyyNOznSMm8ec4=,tag:QOM9DGaPcCjZGQQTMtK5mQ==,type:str]
+sops_lastmodified=2026-06-07T15:23:21Z
+sops_mac=ENC[AES256_GCM,data:fOb98D2rXvMVoKjshLGldi0g0Xrfl94W+1DQXOT9id6IOnDkgApykuQAuKUtcP1YOeSbSbzPdmr6MdF6FAQ49ao8SAYGoBn1egEoXDBaSvPADZyvu371dUuPfxo1YabAGMailEyYD2JNaFXB03Fq32Trv9qSY25VUhyk4aTl3ts=,iv:lYPhk/iuGXIOYpn6ew4tLdIuCE0nycBQdM7azoVZTmA=,tag:PxA54I9S0fdWJNQYXTo+oQ==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.13.1

--- a/secrets/ghost.env.enc
+++ b/secrets/ghost.env.enc
@@ -1,15 +1,17 @@
-GHOST_URL=ENC[AES256_GCM,data:k1BIyxctaY2LhsQUw+7tR64A5nvHOms=,iv:FNIf5IgtnyMFcHyS05b1ZmrU1n48XKf7GFe6xyU9QyE=,tag:WVxvhPAsHj/KgY7n+Tu31g==,type:str]
-GHOST_PORT=ENC[AES256_GCM,data:568gdg==,iv:dczyaRHMBRvCr9yvWlQ+2DjYj7UiDERD5uiapeLahqA=,tag:uC1t9IGSKwk4LEqjojhdkg==,type:str]
-#ENC[AES256_GCM,data:HA7wenPpOldjXeDWAZK6U7abE9Iauqhi9p908Im/wDRGA1QqELi2yY9FMAXONT4ZNhqlTaRT5YPmDpFoPQ4FHotG8eszWuz4ZTJ/wp0=,iv:F8gsv/zINBJ+Kr5moj4Din/kjdXuYOXCy5czpq/YNIw=,tag:1JdSzq7DnUJ6XBymOk5c6A==,type:comment]
-#ENC[AES256_GCM,data:w7AQnlqvo+k0RuNTIKsl531m1AQIT5mmHkrnFQ9+OwMm76gOzFdIW4Z0E5m0,iv:lxlVHJ9JBCseTASe7LqUOvDY/A/uLvwiOuvL+kpO+ao=,tag:8wX3Q0HdHceGjGvWlByr5Q==,type:comment]
-GHOST_NODE_ENV=ENC[AES256_GCM,data:amTJxCQLK3SRvZo=,iv:8Fe6sqPbkjz9NJB90NWKwqQ72fSevFTq2d264IRqcFw=,tag:kPXEhchXkf1YanOpomnZ8Q==,type:str]
-GHOST_CONTENT_DIR=ENC[AES256_GCM,data:+bYmiVjyY5u1,iv:VGjbr7NwJ1iftXnUf+xCaxAMFbQmSO5DiqCmPFWUmF4=,tag:DHPd7FEvbFWnlAUOE1H8tg==,type:str]
-#ENC[AES256_GCM,data:tHDZAL8dSwgdL9dRh9+ju7RdO8aw36TSHXr9PoCRP2CFN4p482v5asVBHuVj0kKlW5CKchQ4lTS4+2EJwrhv3eGWGIyd745LxJE8MMzq,iv:eltPW+enYdC6Dq8chqLOtQz5+O5KqdmvLNzfta4pGWQ=,tag:yILos73Bm94uVE/pn+/KVg==,type:comment]
-#ENC[AES256_GCM,data:vdTn6gpGAWGqnxIANo/ocUS7VTU5710M+AB6MQnybBEYynRiu9WPtd0Q9kmnMKc=,iv:UeqxR9+UIu9OhOGRfoIFRj3XXiDS8IIx3JhLkEiD4Kc=,tag:qcak057rGqdR3xnW2K3IqA==,type:comment]
-GHOST_MAIL_TRANSPORT=ENC[AES256_GCM,data:Z3EeoxIF,iv:1XqoWVK56AFt8ZfTx89FuZlHwvYOK7HzdzQ/+ejkZ/A=,tag:kp844DOefU/hakwQ50d3vw==,type:str]
-sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxKy9leW9ta3pOM2wyeFMr\nRElZZm5rcENJbnErcm84K1EzTm9mRHhyQVJRCkFGS2hLTEhxT0U5Q2RpVkQyM0Ur\nSWltNVJpdU1QTlVqc3FWWnNIMEFqbFUKLS0tIFpyN2x3bjY0d01QUno5dmFISTZO\nTitSMFhkbnh5SHNxdk5MaGVNMi9tbmsKXNVxN91dPAw5BvBVD7tuCFJuSNjLBznB\njRqtZfjTSN6auRW1xBCyJyS3uFHmayGWm+Hv/OUIsSQwoHMYd+wLBA==\n-----END AGE ENCRYPTED FILE-----\n
+GHOST_URL=ENC[AES256_GCM,data:xTeOq2A449CxK4Dkc+SlK3HUNOBeidY=,iv:2UMXlSrqGNojPMq04P6gTzfzLMWYK8+1ebSZz83WJkk=,tag:+lH8P2l3exrgygdltL1vQg==,type:str]
+GHOST_PORT=ENC[AES256_GCM,data:4Gcb2g==,iv:uDj58mj8PrDJCwbXobpoj4kXIe3/ZCC9hENvN6yeXlg=,tag:QvfPUfC825yN4oGG5SMJNA==,type:str]
+#ENC[AES256_GCM,data:m0DuK/oKs1oNJY+w70UxnWGAntww11wxtJS0uCv7yDML2wS09kntR0n3c9t8qE6AT1JeqYjOteXVM1raVRTQ00W/7efchzLJjt6WAX4=,iv:NeeZfyQKqr6CKslhzX8hZKe0FtDnZrRKPFsRGMeg9BQ=,tag:dDo3+CgnwoG5AdykJW5t7Q==,type:comment]
+#ENC[AES256_GCM,data:Gm1rbUwJ9JmJH2sxFoiHqACT7NRiYnGeAx2Mp5zs7ouhUMbGbHqtUJqXJKug,iv:iD952wb61KbxgcRHII8UauVCsjl+ozW/KVldAMavGz4=,tag:mDw8vLmOXD7P1LVm1y/uhQ==,type:comment]
+GHOST_NODE_ENV=ENC[AES256_GCM,data:8H4fe9GD9r35gpk=,iv:dp2xKyqPVgnCFxYf7+bWseYg/9iqziDHv6F4DF5Yk1Y=,tag:EdnIQd3whiv4gUqaWPQzQg==,type:str]
+GHOST_CONTENT_DIR=ENC[AES256_GCM,data:WJ89BNaXW4Gp,iv:CKrrnMO9qlr7z+JSz3OLctgRmoSMeonX55jV3QdpMLM=,tag:TUFuFghObhij4acHnjU4Ew==,type:str]
+#ENC[AES256_GCM,data:Y2AZ+xgqV21tyGzWPcCCQ9/saOjQcq522EdznqBnVQNoPv4u2mn7mRFFgioNasTsVRFfaCrIrwm1XzDP8tMZM4Yw9iRa+XtfNBnmtRHr,iv:Bl6jmgnuXrTNb4g4w2tamtrvBhU9wxQyPA5k4iyIjwk=,tag:Iev6LNbYepQnmZsS9mKKLA==,type:comment]
+#ENC[AES256_GCM,data:cwNpctxNeErCoOkVgrx1vNBcG8V80Z1BmH+pYy8b3lZELjQRbP3kbe+4vHI6NVc=,iv:Ir87XqRf3WXXUMl5XRC/fLzUBjRL8cXbYvRT7xT2rT4=,tag:8scrnN/LvR1ls0oW7keMag==,type:comment]
+GHOST_MAIL_TRANSPORT=ENC[AES256_GCM,data:MNmRTSLw,iv:8K4pYm7Ql2ovnnLupeF5X86EtfpcmeFWz27cUwVTub8=,tag:3xnVz4JNL61qE/xXJBz2Mg==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmQy9scGhqMFpZc0lXZ0Zp\nS2ZPNG9ReEFPRUdIT2N3MGVmdmQ1MlBwSHhzCk5pL0txblB2dU56RUVSc0NYbDlG\nUzNjUkl4aXR5M25iYXNTMkk0ZUF1MlUKLS0tIDFId1k3c1N3WDQxYkQ4elZ4Ty91\nbWliVEdONHY5Vm1wQVYvUVJZbk94VkEKEW95GNlRFeC/CFez2IHx4Uq8UoQ+49sG\nyLgXdGGp63UVd1XoHNwHj8o9WeQo2TBFWrlEVkVFsGVzrrbc2cfNdg==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1lcgsswm7ycfpnlwyul6yh4g84l6lwhmwzehu5sxfhs06vdnjusxqma938u
-sops_lastmodified=2026-06-07T15:23:21Z
-sops_mac=ENC[AES256_GCM,data:fOb98D2rXvMVoKjshLGldi0g0Xrfl94W+1DQXOT9id6IOnDkgApykuQAuKUtcP1YOeSbSbzPdmr6MdF6FAQ49ao8SAYGoBn1egEoXDBaSvPADZyvu371dUuPfxo1YabAGMailEyYD2JNaFXB03Fq32Trv9qSY25VUhyk4aTl3ts=,iv:lYPhk/iuGXIOYpn6ew4tLdIuCE0nycBQdM7azoVZTmA=,tag:PxA54I9S0fdWJNQYXTo+oQ==,type:str]
+sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLSGxSWGd0NXJtVy9LQmNX\naWZIQklwekVyc01TdmxMc3NNQVdmRVU5a0hVCmRUT3grNG1pdis2cEpPZUh2VVh4\naG9wazViNEUrUGEzYzJ1Qm9UNGpYUmMKLS0tIGsxVTZhUWdFTVpXbFI0c3p3Z1Nl\nYXo1ME80Y0F1Rys2dGRiZlVYL1FLZm8K56RsPSnLP7GnIVDNtgj9FBPWWoj5wox/\nbtX2ngpiS8qfKJoIU8+/3WBuPH2xSPQOsn4ZVjcuTGpR5vt65HvuAg==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_1__map_recipient=age1tqhqpn77enh2nskt7flkzah8eanmtsg2m7ef3wvm2gkul30h7ausf2mhy2
+sops_lastmodified=2026-06-07T15:25:33Z
+sops_mac=ENC[AES256_GCM,data:o3J/75mFFoVJecqVwVKDrAu0CeSSbTKnj2ox0mAM3qvnYsc7jiI28Bg4sGWAVMiSMajWoIMGy9wl1ctDfBB/BZqXDJNHTOE+zIHWGEtQSJu2LHor5AQ7b6ke3aV1IkGDmWxIPxpsvJfcJdhBUH6sp49FaP+XcuqtSf5X7EM19lI=,iv:xKHyUrWOAFVsEuQ37X0ntj3efq55w/Tzp+ZB7rFNPqU=,tag:HT9UxkMjFs0pR/llYjKUKA==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.13.1


### PR DESCRIPTION
## Summary

- Replaces the Astro/pm2 deployment workflow with a Ghost CMS Docker Compose deployment to `dohyeon.kr`.
- Adds Nginx configuration for `blog.dohyeon.kr`, with `dohyeon.kr` redirecting to the Ghost site.
- Adds SOPS + age secret management for the Ghost environment file via `secrets/ghost.env.enc`.
- Documents local run, deployment, Nginx, SOPS, and SQLite caveats in `README.md`.

## Validation

- `docker compose config`
- workflow YAML parsed with Ruby `YAML.load_file`
- server `sudo nginx -t`
- server SOPS decrypt of `secrets/ghost.env.enc`
- server `docker compose ps` shows `dohyeon-ghost` running
- loopback HTTPS checks confirmed `dohyeon.kr` redirects to `blog.dohyeon.kr` and `blog.dohyeon.kr/ghost/` returns 200

## Notes

`gh` CLI auth is currently invalid locally, so this PR was opened through the GitHub connector. Ghost is intentionally configured with SQLite for the initial setup; production should move to MySQL 8 before treating it as a supported Ghost production install.