### PR TITLE
fix: run Ghost deploy steps locally on self-hosted runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,41 +36,56 @@ jobs:
         run: |
           pnpm semantic-release || echo "NO_RELEASE=true" >> $GITHUB_ENV
 
-      - name: Prepare remote directories
+      - name: Prepare deployment directories
         run: |
-          ssh dohyeon.kr 'mkdir -p /var/www/ghost-blog/content /var/www/ghost-blog/secrets'
+          mkdir -p /var/www/ghost-blog/content /var/www/ghost-blog/secrets
 
       - name: Ensure SOPS tools are available
         run: |
-          ssh dohyeon.kr 'set -euo pipefail; if ! command -v age >/dev/null 2>&1; then sudo apt-get update && sudo apt-get install -y age; fi; if ! command -v sops >/dev/null 2>&1; then tmp=$(mktemp); curl -fsSL -o "$tmp" https://github.com/getsops/sops/releases/download/v3.13.1/sops-v3.13.1.linux.amd64; sudo install -m 0755 "$tmp" /usr/local/bin/sops; rm -f "$tmp"; fi; test -f "$HOME/.config/sops/age/keys.txt"'
+          set -euo pipefail
+          if ! command -v age >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y age
+          fi
+          if ! command -v sops >/dev/null 2>&1; then
+            tmp=$(mktemp)
+            curl -fsSL -o "$tmp" https://github.com/getsops/sops/releases/download/v3.13.1/sops-v3.13.1.linux.amd64
+            sudo install -m 0755 "$tmp" /usr/local/bin/sops
+            rm -f "$tmp"
+          fi
+          test -f "$HOME/.config/sops/age/keys.txt"
 
       - name: Deploy Ghost compose files
         run: |
-          rsync -avz \
-            docker-compose.yml \
-            .env.example \
-            deploy/nginx/blog.dohyeon.kr.conf \
-            dohyeon.kr:/var/www/ghost-blog/
-          rsync -avz \
-            secrets/ghost.env.enc \
-            dohyeon.kr:/var/www/ghost-blog/secrets/
+          cp docker-compose.yml .env.example deploy/nginx/blog.dohyeon.kr.conf /var/www/ghost-blog/
+          cp secrets/ghost.env.enc /var/www/ghost-blog/secrets/
 
-      - name: Decrypt remote env file
+      - name: Decrypt env file
         run: |
-          ssh dohyeon.kr 'cd /var/www/ghost-blog && SOPS_AGE_KEY_FILE="$HOME/.config/sops/age/keys.txt" sops -d --input-type dotenv --output-type dotenv secrets/ghost.env.enc > .env && chmod 600 .env'
+          cd /var/www/ghost-blog
+          SOPS_AGE_KEY_FILE="$HOME/.config/sops/age/keys.txt" sops -d --input-type dotenv --output-type dotenv secrets/ghost.env.enc > .env
+          chmod 600 .env
 
       - name: Start Ghost with Docker Compose
         run: |
-          ssh dohyeon.kr 'cd /var/www/ghost-blog && docker compose pull && docker compose up -d'
+          cd /var/www/ghost-blog
+          docker compose pull
+          docker compose up -d
 
       - name: Disable legacy Astro Nginx config
         run: |
-          ssh dohyeon.kr 'if [ -f /etc/nginx/conf.d/astro.conf ]; then sudo mv /etc/nginx/conf.d/astro.conf /etc/nginx/conf.d/astro.conf.disabled; fi'
+          if [ -f /etc/nginx/conf.d/astro.conf ]; then
+            sudo mv /etc/nginx/conf.d/astro.conf /etc/nginx/conf.d/astro.conf.disabled
+          fi
 
       - name: Apply Nginx config
         run: |
-          ssh dohyeon.kr 'sudo cp /var/www/ghost-blog/blog.dohyeon.kr.conf /etc/nginx/sites-available/blog.dohyeon.kr && sudo ln -sf /etc/nginx/sites-available/blog.dohyeon.kr /etc/nginx/sites-enabled/blog.dohyeon.kr && sudo nginx -t && sudo systemctl reload nginx'
+          sudo cp /var/www/ghost-blog/blog.dohyeon.kr.conf /etc/nginx/sites-available/blog.dohyeon.kr
+          sudo ln -sf /etc/nginx/sites-available/blog.dohyeon.kr /etc/nginx/sites-enabled/blog.dohyeon.kr
+          sudo nginx -t
+          sudo systemctl reload nginx
 
       - name: Show Ghost status
         run: |
-          ssh dohyeon.kr 'cd /var/www/ghost-blog && docker compose ps'
+          cd /var/www/ghost-blog
+          docker compose ps


### PR DESCRIPTION
### Motivation
- The workflow attempted to SSH to `dohyeon.kr` (port 22) which timed out and caused failures. 
- The self-hosted runner already performs build and deploy steps, so running remote `ssh`/`rsync` is unnecessary and brittle. 
- Running deploy actions locally on the runner avoids attempts to access a non-existent remote target and simplifies the workflow.

### Description
- Removed all `ssh dohyeon.kr` and remote `rsync` usages from `.github/workflows/deploy.yml` and changed the flow to run locally on the self-hosted runner. 
- Replaced remote directory creation with a local `mkdir -p /var/www/ghost-blog/content /var/www/ghost-blog/secrets` step. 
- Moved SOPS/age installation and the `sops` decryption to run on the runner using explicit install checks and `SOPS_AGE_KEY_FILE` usage. 
- Replaced `rsync` with `cp` into `/var/www/ghost-blog`, and run `docker compose`, `nginx` config copy/enable, and `systemctl reload nginx` locally instead of via SSH.

### Testing
- Ran a `python3` check that searched the workflow for `ssh dohyeon.kr` and `dohyeon.kr:/var/www/ghost-blog`, which reported no remote deploy targets remaining (success). 
- Parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml")'`, which parsed successfully (success). 
- Attempted to parse the workflow YAML with `python3` using `yaml.safe_load`, which failed because `PyYAML` was not installed in the runner environment (test failure due to missing dependency). 
- Ran `git diff --check` to validate the patch formatting, which completed successfully (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2615e47160832c91d71b80deea1f42)