### PR TITLE
Fix self-hosted Ghost deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,13 +61,13 @@ jobs:
             docker-compose.yml \
             .env.example \
             deploy/nginx/blog.dohyeon.kr.conf \
-            dohyeon.kr:/var/www/ghost-blog/
+            /var/www/ghost-blog/
           rsync -avz \
             secrets/ghost.env.enc \
-            dohyeon.kr:/var/www/ghost-blog/secrets/
+            /var/www/ghost-blog/secrets/
           rsync -avz --delete \
             themes/monoliquid \
-            dohyeon.kr:/var/www/ghost-blog/themes/
+            /var/www/ghost-blog/themes/
 
       - name: Decrypt env file
         run: |


### PR DESCRIPTION
## Summary
- deploy Ghost files to local /var/www/ghost-blog paths on the self-hosted runner
- remove the remaining dohyeon.kr SSH/rsync target from the deploy step

## Validation
- ruby YAML parse for .github/workflows/deploy.yml
- docker compose config
- rg check for leftover dohyeon.kr SSH targets in the workflow