### PR TITLE
Refine monoliquid theme spacing and borders

### DIFF
--- a/themes/monoliquid/assets/css/screen.css
+++ b/themes/monoliquid/assets/css/screen.css
@@ -1,732 +1,867 @@
 :root {
-    --color-ink: #090909;
-    --color-black: #030304;
-    --color-graphite: #171719;
-    --color-graphite-2: #242427;
-    --color-text: #222224;
-    --color-muted: #6e6e75;
-    --color-hairline: #d6d6d9;
-    --color-soft-hairline: #e8e8ea;
-    --color-background: #f6f6f3;
-    --color-surface: #ffffff;
-    --color-wash: #eeeeec;
-    --color-inverse: #f7f7f2;
-    --color-inverse-muted: #b9b9b4;
-    --radius-sm: 4px;
-    --radius-md: 8px;
-    --radius-base: 12px;
-    --radius-lg: 16px;
-    --radius-pill: 999px;
-    --space-page: clamp(20px, 5vw, 96px);
-    --content-wide: 1248px;
-    --content-prose: 760px;
-    --pattern-blackmetal: url("../images/blackmetal-pattern.png");
-    --shadow-soft: 0 24px 80px rgb(0 0 0 / 0.10);
-    --shadow-dark: 0 28px 90px rgb(0 0 0 / 0.34);
-    --ease-out: cubic-bezier(.2, .8, .2, 1);
+  --color-ink: #090909;
+  --color-black: #030304;
+  --color-graphite: #171719;
+  --color-graphite-2: #242427;
+  --color-text: #222224;
+  --color-muted: #6e6e75;
+  --color-hairline: #d6d6d9;
+  --color-soft-hairline: #e8e8ea;
+  --color-background: #f6f6f3;
+  --color-surface: #ffffff;
+  --color-surface-rgb: 255 255 255;
+  --color-panel: #fbfbf8;
+  --color-wash: #eeeeec;
+  --color-inverse: #f7f7f2;
+  --color-inverse-muted: #b9b9b4;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-base: 12px;
+  --radius-lg: 18px;
+  --radius-pill: 999px;
+  --space-page: clamp(20px, 5vw, 96px);
+  --space-section: clamp(56px, 9vw, 128px);
+  --panel-padding: clamp(24px, 5vw, 64px);
+  --content-wide: 1248px;
+  --content-prose: 760px;
+  --pattern-blackmetal: url("../images/blackmetal-pattern.png");
+  --shadow-soft: 0 24px 80px rgb(0 0 0 / 0.1);
+  --shadow-dark: 0 28px 90px rgb(0 0 0 / 0.34);
+  --border-panel: 1px solid var(--color-soft-hairline);
+  --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
 *,
 *::before,
 *::after {
-    box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 html {
-    background: var(--color-background);
-    color: var(--color-text);
-    font-family:
-        Pretendard,
-        "Noto Sans KR",
-        -apple-system,
-        BlinkMacSystemFont,
-        "Segoe UI",
-        sans-serif;
-    letter-spacing: 0;
+  background: var(--color-background);
+  color: var(--color-text);
+  font-family:
+    Pretendard,
+    "Noto Sans KR",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  letter-spacing: 0;
 }
 
 body {
-    margin: 0;
-    min-width: 320px;
-    background:
-        radial-gradient(circle at 18% 0%, rgb(255 255 255 / 0.88), transparent 34rem),
-        linear-gradient(135deg, #f8f8f4 0%, var(--color-background) 42%, #ececea 100%);
-    color: var(--color-text);
-    font-size: 18px;
-    line-height: 1.75;
-    word-break: keep-all;
-    overflow-wrap: break-word;
+  margin: 0;
+  min-width: 320px;
+  background:
+    radial-gradient(
+      circle at 18% 0%,
+      rgb(255 255 255 / 0.88),
+      transparent 34rem
+    ),
+    radial-gradient(
+      circle at 90% 8%,
+      rgb(255 255 255 / 0.56),
+      transparent 28rem
+    ),
+    linear-gradient(
+      135deg,
+      #f8f8f4 0%,
+      var(--color-background) 42%,
+      #ececea 100%
+    );
+  color: var(--color-text);
+  font-size: 18px;
+  line-height: 1.75;
+  word-break: keep-all;
+  overflow-wrap: break-word;
 }
 
 body::before {
-    content: "";
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    z-index: -1;
-    opacity: 0.16;
-    background-image:
-        linear-gradient(rgb(9 9 9 / 0.06) 1px, transparent 1px),
-        linear-gradient(90deg, rgb(9 9 9 / 0.05) 1px, transparent 1px);
-    background-size: 48px 48px;
-    mask-image: linear-gradient(to bottom, black, transparent 68%);
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: -1;
+  opacity: 0.16;
+  background-image:
+    linear-gradient(rgb(9 9 9 / 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(9 9 9 / 0.05) 1px, transparent 1px);
+  background-size: 44px 44px;
+  mask-image: linear-gradient(to bottom, black, transparent 74%);
 }
 
 img {
-    display: block;
-    max-width: 100%;
-    height: auto;
+  display: block;
+  max-width: 100%;
+  height: auto;
 }
 
 a {
-    color: inherit;
-    text-decoration: none;
+  color: inherit;
+  text-decoration: none;
 }
 
 a:hover {
-    color: var(--color-muted);
+  color: var(--color-muted);
 }
 
 .site-shell {
-    min-height: 100vh;
+  min-height: 100vh;
 }
 
 .site-main {
-    width: min(var(--content-wide), calc(100% - 40px));
-    margin: 0 auto;
-    padding: 32px 0 96px;
+  width: min(var(--content-wide), calc(100% - 40px));
+  margin: 0 auto;
+  padding: 24px 0 112px;
 }
 
 .site-header {
-    position: sticky;
-    top: 0;
-    z-index: 10;
-    padding: 20px var(--space-page) 8px;
-    background: linear-gradient(to bottom, rgb(246 246 243 / 0.92), rgb(246 246 243 / 0.66));
-    backdrop-filter: blur(18px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  padding: 14px var(--space-page) 10px;
+  border-bottom: 1px solid rgb(214 214 217 / 0.54);
+  background: linear-gradient(
+    to bottom,
+    rgb(246 246 243 / 0.94),
+    rgb(246 246 243 / 0.78)
+  );
+  backdrop-filter: blur(18px);
 }
 
 .site-nav {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 24px;
-    width: min(var(--content-wide), 100%);
-    min-height: 72px;
-    margin: 0 auto;
-    padding: 0 24px;
-    border: 1px solid var(--color-soft-hairline);
-    border-radius: var(--radius-base);
-    background: rgb(246 246 243 / 0.72);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  width: min(var(--content-wide), 100%);
+  min-height: 64px;
+  margin: 0 auto;
+  padding: 0 18px;
+  border: var(--border-panel);
+  border-radius: var(--radius-lg);
+  background: rgb(var(--color-surface-rgb) / 0.62);
+  box-shadow: 0 1px 0 rgb(255 255 255 / 0.8) inset;
 }
 
 .site-brand {
-    display: inline-flex;
-    align-items: center;
-    min-width: 0;
-    color: var(--color-ink);
-    font-size: 18px;
-    font-weight: 800;
-    line-height: 1.1;
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  color: var(--color-ink);
+  font-size: 18px;
+  font-weight: 800;
+  line-height: 1.1;
 }
 
 .site-brand img {
-    width: auto;
-    max-height: 32px;
+  width: auto;
+  max-height: 32px;
 }
 
 .nav {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex: 1;
-    gap: 8px;
-    padding: 0;
-    margin: 0;
-    list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  gap: 8px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
 }
 
 .nav a {
-    display: inline-flex;
-    align-items: center;
-    min-height: 36px;
-    padding: 0 12px;
-    border-radius: var(--radius-pill);
-    color: var(--color-muted);
-    font-size: 14px;
-    font-weight: 700;
-    transition:
-        color 160ms var(--ease-out),
-        background 160ms var(--ease-out);
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  padding: 0 12px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  color: var(--color-muted);
+  font-size: 14px;
+  font-weight: 700;
+  transition:
+    color 160ms var(--ease-out),
+    background 160ms var(--ease-out);
 }
 
 .nav-current a,
 .nav a:hover {
-    background: var(--color-surface);
-    color: var(--color-ink);
+  border-color: var(--color-soft-hairline);
+  background: var(--color-surface);
+  color: var(--color-ink);
 }
 
 .site-nav__actions {
-    min-width: 112px;
-    display: flex;
-    justify-content: flex-end;
+  min-width: 112px;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 44px;
-    padding: 0 18px;
-    border: 1px solid transparent;
-    border-radius: var(--radius-base);
-    font-size: 14px;
-    font-weight: 800;
-    line-height: 1;
-    transition:
-        transform 160ms var(--ease-out),
-        border-color 160ms var(--ease-out),
-        background 160ms var(--ease-out),
-        color 160ms var(--ease-out);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 18px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-base);
+  font-size: 14px;
+  font-weight: 800;
+  line-height: 1;
+  transition:
+    transform 160ms var(--ease-out),
+    border-color 160ms var(--ease-out),
+    background 160ms var(--ease-out),
+    color 160ms var(--ease-out);
 }
 
 .button:hover {
-    transform: translateY(-1px);
+  transform: translateY(-1px);
 }
 
 .button--primary {
-    background: var(--color-ink);
-    color: var(--color-inverse);
-    box-shadow: 0 12px 28px rgb(0 0 0 / 0.16);
+  background: var(--color-ink);
+  color: var(--color-inverse);
+  box-shadow: 0 12px 28px rgb(0 0 0 / 0.16);
 }
 
 .button--secondary {
-    border-color: var(--color-hairline);
-    background: var(--color-surface);
-    color: var(--color-text);
+  border-color: var(--color-hairline);
+  background: var(--color-surface);
+  color: var(--color-text);
 }
 
 .button--inverse {
-    background: var(--color-inverse);
-    color: var(--color-ink);
+  background: var(--color-inverse);
+  color: var(--color-ink);
 }
 
 .button--small {
-    min-height: 36px;
-    padding-inline: 14px;
-    background: var(--color-ink);
-    color: var(--color-inverse);
+  min-height: 36px;
+  padding-inline: 14px;
+  background: var(--color-ink);
+  color: var(--color-inverse);
 }
 
 .eyebrow {
-    margin: 0 0 20px;
-    color: var(--color-muted);
-    font-size: 12px;
-    font-weight: 800;
-    line-height: 1.4;
-    text-transform: uppercase;
+  margin: 0 0 20px;
+  color: var(--color-muted);
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1.4;
+  text-transform: uppercase;
 }
 
 .eyebrow--inverse {
-    color: var(--color-inverse-muted);
+  color: var(--color-inverse-muted);
 }
 
 .hero {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(360px, 520px);
-    gap: clamp(32px, 6vw, 96px);
-    align-items: center;
-    min-height: min(760px, calc(100vh - 140px));
-    padding: 44px 0 72px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(360px, 520px);
+  position: relative;
+  gap: clamp(28px, 5vw, 72px);
+  align-items: stretch;
+  min-height: min(720px, calc(100vh - 132px));
+  margin-top: 20px;
+  margin-bottom: var(--space-section);
+  padding: var(--panel-padding);
+  overflow: hidden;
+  border: var(--border-panel);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(
+      135deg,
+      rgb(var(--color-surface-rgb) / 0.88),
+      rgb(246 246 243 / 0.72)
+    ),
+    linear-gradient(var(--color-soft-hairline) 1px, transparent 1px),
+    linear-gradient(90deg, var(--color-soft-hairline) 1px, transparent 1px);
+  background-size:
+    auto,
+    36px 36px,
+    36px 36px;
+  box-shadow: 0 1px 0 rgb(255 255 255 / 0.9) inset;
+}
+
+.hero__copy {
+  align-self: center;
 }
 
 .hero__copy h1 {
-    max-width: 680px;
-    margin: 0;
-    color: var(--color-ink);
-    font-size: clamp(56px, 8vw, 96px);
-    font-weight: 800;
-    line-height: 1.02;
+  max-width: 680px;
+  margin: 0;
+  color: var(--color-ink);
+  font-size: clamp(56px, 8vw, 96px);
+  font-weight: 800;
+  line-height: 1.02;
 }
 
 .hero__dek {
-    max-width: 640px;
-    margin: 28px 0 0;
-    color: var(--color-muted);
-    font-size: clamp(20px, 2.1vw, 28px);
-    font-weight: 700;
-    line-height: 1.38;
+  max-width: 640px;
+  margin: 28px 0 0;
+  color: var(--color-muted);
+  font-size: clamp(20px, 2.1vw, 28px);
+  font-weight: 700;
+  line-height: 1.38;
 }
 
 .hero__actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 16px;
-    margin-top: 40px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 40px;
 }
 
 .hero__metal {
-    position: relative;
-    min-height: 620px;
-    overflow: hidden;
-    border: 1px solid rgb(255 255 255 / 0.20);
-    border-radius: var(--radius-base);
-    background:
-        linear-gradient(135deg, rgb(0 0 0 / 0.08), rgb(0 0 0 / 0.30)),
-        var(--pattern-blackmetal) center / cover;
-    box-shadow: var(--shadow-dark);
+  position: relative;
+  min-height: 100%;
+  overflow: hidden;
+  border: 1px solid #303034;
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(135deg, rgb(0 0 0 / 0.08), rgb(0 0 0 / 0.3)),
+    var(--pattern-blackmetal) center / cover;
+  box-shadow: 0 1px 0 rgb(255 255 255 / 0.12) inset;
 }
 
 .hero__metal::after {
-    content: "";
-    position: absolute;
-    right: 52px;
-    bottom: 34px;
-    width: 344px;
-    height: 126px;
-    border-radius: var(--radius-base);
-    background: rgb(0 0 0 / 0.48);
+  content: "";
+  position: absolute;
+  right: 52px;
+  bottom: 34px;
+  width: 344px;
+  height: 126px;
+  border-radius: var(--radius-base);
+  background: rgb(0 0 0 / 0.48);
 }
 
 .hero__metal span {
-    position: absolute;
-    right: 72px;
-    bottom: 78px;
-    z-index: 1;
-    color: var(--color-inverse);
-    font-size: 16px;
-    font-weight: 800;
+  position: absolute;
+  right: 72px;
+  bottom: 78px;
+  z-index: 1;
+  color: var(--color-inverse);
+  font-size: 16px;
+  font-weight: 800;
 }
 
 .newsletter-band {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 24px;
-    margin-bottom: 72px;
-    padding: 32px;
-    border: 1px solid #303034;
-    border-radius: var(--radius-base);
-    background:
-        linear-gradient(90deg, rgb(0 0 0 / 0.76), rgb(0 0 0 / 0.38)),
-        var(--pattern-blackmetal) center / cover;
-    color: var(--color-inverse);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: var(--space-section);
+  padding: clamp(28px, 4vw, 48px);
+  border: 1px solid #303034;
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(90deg, rgb(0 0 0 / 0.76), rgb(0 0 0 / 0.38)),
+    var(--pattern-blackmetal) center / cover;
+  color: var(--color-inverse);
 }
 
 .newsletter-band h2 {
-    margin: 0;
-    font-size: clamp(24px, 3vw, 36px);
-    line-height: 1.22;
+  margin: 0;
+  font-size: clamp(24px, 3vw, 36px);
+  line-height: 1.22;
 }
 
 .newsletter-band p:last-child {
-    margin: 10px 0 0;
-    color: var(--color-inverse-muted);
-    font-size: 15px;
+  margin: 10px 0 0;
+  color: var(--color-inverse-muted);
+  font-size: 15px;
 }
 
 .section-heading,
 .archive-header {
-    margin-bottom: 32px;
+  margin-bottom: 0;
+}
+
+.section-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 0 0 24px;
+  border-bottom: var(--border-panel);
+}
+
+.post-index {
+  padding-top: var(--space-section);
+  border-top: var(--border-panel);
 }
 
 .section-heading h2,
 .archive-header h1 {
-    margin: 0;
-    color: var(--color-ink);
-    font-size: clamp(36px, 5vw, 56px);
-    font-weight: 800;
-    line-height: 1.14;
+  margin: 0;
+  color: var(--color-ink);
+  font-size: clamp(36px, 5vw, 56px);
+  font-weight: 800;
+  line-height: 1.14;
 }
 
 .archive-header {
-    max-width: 760px;
-    padding: 88px 0 48px;
+  max-width: 760px;
+  padding: 88px 0 48px;
 }
 
 .archive-header p:not(.eyebrow) {
-    color: var(--color-muted);
-    font-size: 20px;
+  color: var(--color-muted);
+  font-size: 20px;
 }
 
 .post-grid {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 24px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0;
+  overflow: hidden;
+  border: var(--border-panel);
+  border-top: 0;
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  background: var(--color-surface);
+}
+
+.archive-header + .post-grid {
+  border-top: var(--border-panel);
+  border-radius: var(--radius-lg);
 }
 
 .post-card {
-    min-width: 0;
-    overflow: hidden;
-    border: 1px solid var(--color-soft-hairline);
-    border-radius: var(--radius-base);
-    background: var(--color-surface);
-    box-shadow: 0 12px 36px rgb(0 0 0 / 0.06);
-    transition:
-        transform 180ms var(--ease-out),
-        box-shadow 180ms var(--ease-out),
-        border-color 180ms var(--ease-out);
+  min-width: 0;
+  overflow: hidden;
+  border: 0;
+  border-right: var(--border-panel);
+  border-bottom: var(--border-panel);
+  border-radius: 0;
+  background: rgb(var(--color-surface-rgb) / 0.86);
+  transition:
+    background 180ms var(--ease-out),
+    border-color 180ms var(--ease-out);
+}
+
+.post-card:nth-child(3n) {
+  border-right: 0;
 }
 
 .post-card:hover {
-    transform: translateY(-3px);
-    border-color: var(--color-hairline);
-    box-shadow: var(--shadow-soft);
+  border-color: var(--color-hairline);
+  background: var(--color-panel);
 }
 
 .post-card__media {
-    display: block;
-    margin: 18px 18px 0;
-    overflow: hidden;
-    border-radius: 10px;
-    background: var(--color-black);
-    aspect-ratio: 16 / 7;
+  display: block;
+  margin: 16px 16px 0;
+  overflow: hidden;
+  border: 1px solid var(--color-soft-hairline);
+  border-radius: var(--radius-base);
+  background: var(--color-black);
+  aspect-ratio: 16 / 7;
 }
 
 .post-card__media img,
 .post-card__metal {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .post-card__metal {
-    display: block;
-    background:
-        linear-gradient(rgb(0 0 0 / 0.24), rgb(0 0 0 / 0.24)),
-        var(--pattern-blackmetal) center / cover;
+  display: block;
+  background:
+    linear-gradient(rgb(0 0 0 / 0.24), rgb(0 0 0 / 0.24)),
+    var(--pattern-blackmetal) center / cover;
 }
 
 .post-card__body {
-    padding: 22px 20px 24px;
+  padding: 22px 24px 28px;
 }
 
 .post-card__meta,
 .article-header__meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    align-items: center;
-    margin-bottom: 16px;
-    color: var(--color-muted);
-    font-size: 12px;
-    font-weight: 800;
-    line-height: 1.4;
-    text-transform: uppercase;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 16px;
+  color: var(--color-muted);
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1.4;
+  text-transform: uppercase;
 }
 
 .post-card__meta a,
 .article-header__meta a,
 .tag-row a {
-    color: inherit;
+  color: inherit;
 }
 
 .post-card__title {
-    display: block;
-    color: var(--color-text);
-    font-size: 24px;
-    font-weight: 800;
-    line-height: 1.25;
+  display: block;
+  color: var(--color-text);
+  font-size: 24px;
+  font-weight: 800;
+  line-height: 1.25;
 }
 
 .post-card p {
-    margin: 16px 0 0;
-    color: var(--color-muted);
-    font-size: 15px;
-    line-height: 1.65;
+  margin: 16px 0 0;
+  color: var(--color-muted);
+  font-size: 15px;
+  line-height: 1.65;
 }
 
 .article {
-    width: min(var(--content-prose), 100%);
-    margin: 0 auto;
-    padding: 84px 0 96px;
+  width: min(960px, 100%);
+  margin: 0 auto;
+  padding: 72px 0 104px;
 }
 
 .article-header {
-    margin-bottom: 44px;
+  margin-bottom: 0;
+  padding: clamp(28px, 5vw, 56px);
+  border: var(--border-panel);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  background:
+    linear-gradient(
+      135deg,
+      rgb(var(--color-surface-rgb) / 0.92),
+      rgb(246 246 243 / 0.72)
+    ),
+    linear-gradient(var(--color-soft-hairline) 1px, transparent 1px),
+    linear-gradient(90deg, var(--color-soft-hairline) 1px, transparent 1px);
+  background-size:
+    auto,
+    36px 36px,
+    36px 36px;
 }
 
 .article-header h1 {
-    margin: 0;
-    color: var(--color-ink);
-    font-size: clamp(42px, 6vw, 72px);
-    font-weight: 800;
-    line-height: 1.12;
+  margin: 0;
+  color: var(--color-ink);
+  font-size: clamp(42px, 6vw, 72px);
+  font-weight: 800;
+  line-height: 1.12;
 }
 
 .article-header__dek {
-    margin: 26px 0 0;
-    color: var(--color-muted);
-    font-size: 20px;
-    font-weight: 400;
-    line-height: 1.7;
+  margin: 26px 0 0;
+  color: var(--color-muted);
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 1.7;
 }
 
 .article-image,
 .article-metal {
-    width: min(860px, calc(100vw - 40px));
-    margin: 0 50% 56px;
-    transform: translateX(-50%);
+  width: 100%;
+  margin: 0 0 0;
+  transform: none;
 }
 
 .article-image img,
 .article-metal {
-    width: 100%;
-    overflow: hidden;
-    border-radius: var(--radius-base);
-    box-shadow: var(--shadow-soft);
+  width: 100%;
+  overflow: hidden;
+  border-right: var(--border-panel);
+  border-left: var(--border-panel);
+  border-radius: 0;
 }
 
 .article-metal {
-    height: 220px;
-    background:
-        linear-gradient(rgb(0 0 0 / 0.18), rgb(0 0 0 / 0.18)),
-        var(--pattern-blackmetal) center / cover;
+  height: 220px;
+  background:
+    linear-gradient(rgb(0 0 0 / 0.18), rgb(0 0 0 / 0.18)),
+    var(--pattern-blackmetal) center / cover;
 }
 
 .article-image figcaption {
-    margin-top: 10px;
-    color: var(--color-muted);
-    font-size: 13px;
-    text-align: center;
+  margin-top: 10px;
+  color: var(--color-muted);
+  font-size: 13px;
+  text-align: center;
 }
 
 .gh-content {
-    color: var(--color-text);
-    font-size: 19px;
-    line-height: 1.82;
+  max-width: none;
+  padding: clamp(32px, 5vw, 56px);
+  border: var(--border-panel);
+  border-top: 0;
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  background: rgb(var(--color-surface-rgb) / 0.76);
+  color: var(--color-text);
+  font-size: 19px;
+  line-height: 1.82;
+}
+
+.gh-content--with-footer {
+  border-radius: 0;
+}
+
+.gh-content > * {
+  max-width: var(--content-prose);
+  margin-right: auto;
+  margin-left: auto;
 }
 
 .gh-content > * + * {
-    margin-top: 1.3em;
+  margin-top: 1.3em;
 }
 
 .gh-content h2,
 .gh-content h3,
 .gh-content h4 {
-    color: var(--color-ink);
-    line-height: 1.28;
+  color: var(--color-ink);
+  line-height: 1.28;
 }
 
 .gh-content h2 {
-    margin-top: 2.2em;
-    font-size: 36px;
+  margin-top: 2.2em;
+  font-size: 36px;
 }
 
 .gh-content h3 {
-    margin-top: 2em;
-    font-size: 28px;
+  margin-top: 2em;
+  font-size: 28px;
 }
 
 .gh-content a {
-    color: var(--color-ink);
-    text-decoration: underline;
-    text-decoration-color: var(--color-hairline);
-    text-underline-offset: 0.18em;
+  color: var(--color-ink);
+  text-decoration: underline;
+  text-decoration-color: var(--color-hairline);
+  text-underline-offset: 0.18em;
 }
 
 .gh-content blockquote {
-    margin: 2em 0;
-    padding: 24px 28px;
-    border-left: 6px solid var(--color-ink);
-    border-radius: var(--radius-base);
-    background: var(--color-surface);
-    color: var(--color-text);
-    font-size: 24px;
-    font-weight: 700;
-    line-height: 1.46;
+  margin: 2em auto;
+  padding: 24px 28px;
+  border: var(--border-panel);
+  border-left: 6px solid var(--color-ink);
+  border-radius: var(--radius-base);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 1.46;
 }
 
 .gh-content pre {
-    overflow-x: auto;
-    padding: 24px;
-    border: 1px solid #303034;
-    border-radius: var(--radius-base);
-    background: #111113;
-    color: #d8d8d3;
-    font-size: 15px;
-    line-height: 1.6;
+  overflow-x: auto;
+  padding: 24px;
+  border: 1px solid #303034;
+  border-radius: var(--radius-base);
+  background: #111113;
+  color: #d8d8d3;
+  font-size: 15px;
+  line-height: 1.6;
 }
 
 .gh-content code {
-    border-radius: var(--radius-sm);
-    background: var(--color-wash);
-    padding: 0.12em 0.34em;
-    font-size: 0.88em;
+  border-radius: var(--radius-sm);
+  background: var(--color-wash);
+  padding: 0.12em 0.34em;
+  font-size: 0.88em;
 }
 
 .gh-content pre code {
-    padding: 0;
-    background: transparent;
+  padding: 0;
+  background: transparent;
 }
 
 .gh-content img,
 .kg-image-card img,
 .kg-gallery-image img {
-    border-radius: var(--radius-base);
+  border-radius: var(--radius-base);
 }
 
 .kg-card figcaption {
-    color: var(--color-muted);
-    font-size: 13px;
-    text-align: center;
+  color: var(--color-muted);
+  font-size: 13px;
+  text-align: center;
 }
 
 .kg-width-wide {
-    width: min(1020px, calc(100vw - 40px));
-    margin-left: 50%;
-    transform: translateX(-50%);
+  max-width: min(1020px, 100%);
 }
 
 .kg-width-full {
-    width: calc(100vw - 40px);
-    margin-left: 50%;
-    transform: translateX(-50%);
+  max-width: none;
+  width: 100%;
 }
 
 .kg-width-full img,
 .kg-width-wide img {
-    width: 100%;
+  width: 100%;
 }
 
 .article-footer {
-    margin-top: 56px;
-    padding-top: 24px;
-    border-top: 1px solid var(--color-soft-hairline);
+  margin-top: 0;
+  padding: 24px clamp(32px, 5vw, 56px);
+  border: var(--border-panel);
+  border-top: 0;
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  background: rgb(var(--color-surface-rgb) / 0.76);
 }
 
 .tag-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 
 .tag-row a {
-    display: inline-flex;
-    min-height: 36px;
-    align-items: center;
-    padding: 0 14px;
-    border: 1px solid var(--color-soft-hairline);
-    border-radius: var(--radius-pill);
-    background: var(--color-surface);
-    color: var(--color-muted);
-    font-size: 13px;
-    font-weight: 800;
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  padding: 0 14px;
+  border: 1px solid var(--color-soft-hairline);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+  color: var(--color-muted);
+  font-size: 13px;
+  font-weight: 800;
 }
 
 .pagination {
-    display: flex;
-    justify-content: center;
-    gap: 16px;
-    margin-top: 56px;
-    color: var(--color-muted);
-    font-size: 14px;
-    font-weight: 800;
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 56px;
+  color: var(--color-muted);
+  font-size: 14px;
+  font-weight: 800;
 }
 
 .site-footer {
-    display: flex;
-    justify-content: space-between;
-    gap: 24px;
-    width: min(var(--content-wide), calc(100% - 40px));
-    margin: 0 auto;
-    padding: 48px 0 72px;
-    border-top: 1px solid var(--color-soft-hairline);
-    color: var(--color-muted);
-    font-size: 14px;
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  width: min(var(--content-wide), calc(100% - 40px));
+  margin: 0 auto 32px;
+  padding: 28px 32px;
+  border: var(--border-panel);
+  border-radius: var(--radius-lg);
+  background: rgb(var(--color-surface-rgb) / 0.58);
+  color: var(--color-muted);
+  font-size: 14px;
 }
 
 .site-footer__brand {
-    color: var(--color-ink);
-    font-size: 22px;
-    font-weight: 800;
+  color: var(--color-ink);
+  font-size: 22px;
+  font-weight: 800;
 }
 
 .site-footer p {
-    margin: 8px 0 0;
+  margin: 8px 0 0;
 }
 
 .site-footer__fine {
-    white-space: nowrap;
+  white-space: nowrap;
 }
 
 @media (max-width: 980px) {
-    .site-nav {
-        align-items: flex-start;
-        flex-direction: column;
-        padding: 18px;
-    }
+  .site-nav {
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 18px;
+  }
 
-    .nav {
-        justify-content: flex-start;
-        flex-wrap: wrap;
-    }
+  .nav {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
 
-    .site-nav__actions {
-        min-width: 0;
-        justify-content: flex-start;
-    }
+  .site-nav__actions {
+    min-width: 0;
+    justify-content: flex-start;
+  }
 
-    .hero {
-        grid-template-columns: 1fr;
-        min-height: 0;
-    }
+  .hero {
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
 
-    .hero__metal {
-        min-height: 360px;
-    }
+  .hero__metal {
+    min-height: 360px;
+  }
 
-    .post-grid {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
+  .post-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .post-card:nth-child(3n) {
+    border-right: var(--border-panel);
+  }
+
+  .post-card:nth-child(2n) {
+    border-right: 0;
+  }
 }
 
 @media (max-width: 680px) {
-    body {
-        font-size: 16px;
-    }
+  body {
+    font-size: 16px;
+  }
 
-    .site-main {
-        width: min(100% - 32px, var(--content-wide));
-        padding-top: 20px;
-    }
+  .site-main {
+    width: min(100% - 32px, var(--content-wide));
+    padding-top: 20px;
+  }
 
-    .site-header {
-        padding-inline: 16px;
-    }
+  .site-header {
+    padding-inline: 16px;
+  }
 
-    .hero {
-        padding-top: 32px;
-    }
+  .hero {
+    padding-top: 32px;
+  }
 
-    .hero__copy h1 {
-        font-size: 48px;
-    }
+  .hero__copy {
+    align-self: center;
+  }
 
-    .hero__metal {
-        min-height: 280px;
-    }
+  .hero__copy h1 {
+    font-size: 48px;
+  }
 
-    .newsletter-band,
-    .site-footer {
-        align-items: flex-start;
-        flex-direction: column;
-    }
+  .hero__metal {
+    min-height: 280px;
+  }
 
-    .post-grid {
-        grid-template-columns: 1fr;
-    }
+  .section-heading {
+    display: block;
+  }
 
-    .article {
-        padding-top: 56px;
-    }
+  .newsletter-band,
+  .site-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
 
-    .article-header h1 {
-        font-size: 40px;
-    }
+  .post-grid {
+    grid-template-columns: 1fr;
+  }
 
-    .gh-content {
-        font-size: 17px;
-        line-height: 1.78;
-    }
+  .post-card,
+  .post-card:nth-child(2n),
+  .post-card:nth-child(3n) {
+    border-right: 0;
+  }
+
+  .article {
+    padding-top: 56px;
+  }
+
+  .article-header h1 {
+    font-size: 40px;
+  }
+
+  .gh-content {
+    font-size: 17px;
+    line-height: 1.78;
+  }
 }

--- a/themes/monoliquid/post.hbs
+++ b/themes/monoliquid/post.hbs
@@ -35,7 +35,7 @@
                 <div class="article-metal" aria-hidden="true"></div>
             {{/if}}
 
-            <section class="gh-content">
+            <section class="gh-content gh-content--with-footer">
                 {{content}}
             </section>
 


### PR DESCRIPTION
### Motivation
- Bring Vite-like panel/border and spacing treatment into the Monoliquid theme while preserving the existing monochrome / blackmetal aesthetic. 
- Use shared design tokens so sections and stacked article pieces read as connected panels rather than isolated cards.

### Description
- Added new CSS tokens (`--space-section`, `--panel-padding`, `--border-panel`, `--color-surface-rgb`, `--color-panel`) and tuned radii to centralize spacing and panel styling in `themes/monoliquid/assets/css/screen.css`.
- Reworked header/navigation, hero, newsletter band, post grid, post card, article header, and footer to use thin panel borders and surface treatments instead of loose card spacing in `screen.css`.
- Converted the post detail layout so article header, content, and footer form a single bordered shell by adding `gh-content--with-footer` and applying the modifier in `themes/monoliquid/post.hbs`.
- Adjusted responsive rules and various paddings/margins to keep the original look while improving section boundary clarity and alignment.

### Testing
- Ran formatting checks with `npx prettier --check themes/monoliquid/assets/css/screen.css` which passed after formatting changes were applied with `npx prettier --write`.
- Ran `git diff --check` and a custom Python brace-balance script against `themes/monoliquid/assets/css/screen.css` which both reported no issues.
- Attempted `npx @tryghost/gscan themes/monoliquid` but the registry access returned `403 Forbidden` in this environment so theme linting could not be completed here.
- Screenshot / headless browser checks were not performed because no browser/playwright binary was available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bd15e72d4832cb41f4fa1fb21212b)