### PR TITLE
Add decorative tick accents and refine theme styling (colors, radii, button pattern)

### DIFF
--- a/themes/monoliquid/assets/css/screen.css
+++ b/themes/monoliquid/assets/css/screen.css
@@ -5,8 +5,9 @@
   --color-graphite-2: #242427;
   --color-text: #222224;
   --color-muted: #6e6e75;
-  --color-hairline: #d6d6d9;
-  --color-soft-hairline: #e8e8ea;
+  --color-hairline: #c8c8cc;
+  --color-soft-hairline: #dddddf;
+  --color-stroke: #1d1d20;
   --color-background: #f6f6f3;
   --color-surface: #ffffff;
   --color-surface-rgb: 255 255 255;
@@ -14,10 +15,10 @@
   --color-wash: #eeeeec;
   --color-inverse: #f7f7f2;
   --color-inverse-muted: #b9b9b4;
-  --radius-sm: 4px;
-  --radius-md: 8px;
-  --radius-base: 12px;
-  --radius-lg: 18px;
+  --radius-sm: 3px;
+  --radius-md: 6px;
+  --radius-base: 8px;
+  --radius-lg: 12px;
   --radius-pill: 999px;
   --space-page: clamp(20px, 5vw, 96px);
   --space-section: clamp(56px, 9vw, 128px);
@@ -27,7 +28,7 @@
   --pattern-blackmetal: url("../images/blackmetal-pattern.png");
   --shadow-soft: 0 24px 80px rgb(0 0 0 / 0.1);
   --shadow-dark: 0 28px 90px rgb(0 0 0 / 0.34);
-  --border-panel: 1px solid var(--color-soft-hairline);
+  --border-panel: 1px solid var(--color-hairline);
   --ease-out: cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
@@ -83,12 +84,33 @@ body::before {
   inset: 0;
   pointer-events: none;
   z-index: -1;
-  opacity: 0.16;
+  opacity: 0.24;
   background-image:
-    linear-gradient(rgb(9 9 9 / 0.06) 1px, transparent 1px),
-    linear-gradient(90deg, rgb(9 9 9 / 0.05) 1px, transparent 1px);
-  background-size: 44px 44px;
+    linear-gradient(rgb(9 9 9 / 0.1) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(9 9 9 / 0.09) 1px, transparent 1px);
+  background-size: 40px 40px;
   mask-image: linear-gradient(to bottom, black, transparent 74%);
+}
+
+.wrapper--ticks,
+.tick-right {
+  position: relative;
+}
+
+.wrapper--ticks::after,
+.tick-right::after {
+  content: "";
+  position: absolute;
+  top: -5px;
+  right: 0;
+  z-index: 2;
+  width: 0;
+  height: 0;
+  border-top: 5px solid #0000;
+  border-right: 5px solid var(--color-stroke);
+  border-bottom: 5px solid #0000;
+  border-left: 5px solid #0000;
+  pointer-events: none;
 }
 
 img {
@@ -113,7 +135,7 @@ a:hover {
 .site-main {
   width: min(var(--content-wide), calc(100% - 40px));
   margin: 0 auto;
-  padding: 24px 0 112px;
+  padding: 24px 0 64px;
 }
 
 .site-header {
@@ -213,8 +235,17 @@ a:hover {
   transition:
     transform 160ms var(--ease-out),
     border-color 160ms var(--ease-out),
-    background 160ms var(--ease-out),
     color 160ms var(--ease-out);
+}
+
+@keyframes pattern-marquee {
+  from {
+    background-position: 0 50%;
+  }
+
+  to {
+    background-position: 220px 50%;
+  }
 }
 
 .button:hover {
@@ -222,9 +253,12 @@ a:hover {
 }
 
 .button--primary {
-  background: var(--color-ink);
+  background:
+    linear-gradient(rgb(0 0 0 / 0.18), rgb(0 0 0 / 0.18)),
+    var(--pattern-blackmetal) 0 50% / 220px auto repeat;
   color: var(--color-inverse);
   box-shadow: 0 12px 28px rgb(0 0 0 / 0.16);
+  animation: pattern-marquee 7s linear infinite;
 }
 
 .button--secondary {
@@ -241,8 +275,11 @@ a:hover {
 .button--small {
   min-height: 36px;
   padding-inline: 14px;
-  background: var(--color-ink);
+  background:
+    linear-gradient(rgb(0 0 0 / 0.18), rgb(0 0 0 / 0.18)),
+    var(--pattern-blackmetal) 0 50% / 220px auto repeat;
   color: var(--color-inverse);
+  animation: pattern-marquee 7s linear infinite;
 }
 
 .eyebrow {
@@ -277,12 +314,12 @@ a:hover {
       rgb(var(--color-surface-rgb) / 0.88),
       rgb(246 246 243 / 0.72)
     ),
-    linear-gradient(var(--color-soft-hairline) 1px, transparent 1px),
-    linear-gradient(90deg, var(--color-soft-hairline) 1px, transparent 1px);
+    linear-gradient(rgb(29 29 32 / 0.16) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(29 29 32 / 0.14) 1px, transparent 1px);
   background-size:
     auto,
-    36px 36px,
-    36px 36px;
+    32px 32px,
+    32px 32px;
   box-shadow: 0 1px 0 rgb(255 255 255 / 0.9) inset;
 }
 
@@ -531,12 +568,12 @@ a:hover {
       rgb(var(--color-surface-rgb) / 0.92),
       rgb(246 246 243 / 0.72)
     ),
-    linear-gradient(var(--color-soft-hairline) 1px, transparent 1px),
-    linear-gradient(90deg, var(--color-soft-hairline) 1px, transparent 1px);
+    linear-gradient(rgb(29 29 32 / 0.16) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(29 29 32 / 0.14) 1px, transparent 1px);
   background-size:
     auto,
-    36px 36px,
-    36px 36px;
+    32px 32px,
+    32px 32px;
 }
 
 .article-header h1 {
@@ -740,8 +777,9 @@ a:hover {
   justify-content: space-between;
   gap: 24px;
   width: min(var(--content-wide), calc(100% - 40px));
-  margin: 0 auto 32px;
-  padding: 28px 32px;
+  align-items: center;
+  margin: 0 auto 20px;
+  padding: 22px 28px;
   border: var(--border-panel);
   border-radius: var(--radius-lg);
   background: rgb(var(--color-surface-rgb) / 0.58);
@@ -756,11 +794,19 @@ a:hover {
 }
 
 .site-footer p {
-  margin: 8px 0 0;
+  margin: 6px 0 0;
 }
 
 .site-footer__fine {
+  margin: 0;
   white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .button--primary,
+  .button--small {
+    animation: none;
+  }
 }
 
 @media (max-width: 980px) {

--- a/themes/monoliquid/author.hbs
+++ b/themes/monoliquid/author.hbs
@@ -11,7 +11,7 @@
         {{/author}}
     </section>
 
-    <div class="post-grid">
+    <div class="post-grid wrapper--ticks">
         {{#foreach posts}}
             {{> "post-card"}}
         {{/foreach}}

--- a/themes/monoliquid/index.hbs
+++ b/themes/monoliquid/index.hbs
@@ -1,7 +1,7 @@
 {{!< default}}
 
 <main class="site-main">
-    <section class="hero">
+    <section class="hero wrapper--ticks">
         <div class="hero__copy">
             <p class="eyebrow">Ghost theme concept / Personal tech magazine</p>
             <h1>{{@site.title}}</h1>
@@ -21,7 +21,7 @@
     </section>
 
     {{#if @site.members_enabled}}
-        <section class="newsletter-band">
+        <section class="newsletter-band wrapper--ticks">
             <div>
                 <p class="eyebrow eyebrow--inverse">Subscribe</p>
                 <h2>새 글을 조용히 받아보기</h2>
@@ -32,12 +32,12 @@
     {{/if}}
 
     <section id="posts" class="post-index">
-        <div class="section-heading">
+        <div class="section-heading tick-right">
             <p class="eyebrow">Latest</p>
             <h2>최근 글</h2>
         </div>
 
-        <div class="post-grid">
+        <div class="post-grid wrapper--ticks">
             {{#foreach posts}}
                 {{> "post-card"}}
             {{/foreach}}

--- a/themes/monoliquid/page.hbs
+++ b/themes/monoliquid/page.hbs
@@ -4,7 +4,7 @@
     {{#post}}
         <article class="article {{post_class}}">
             {{#if @page.show_title_and_feature_image}}
-                <header class="article-header">
+                <header class="article-header wrapper--ticks">
                     <p class="eyebrow">Page</p>
                     <h1>{{title}}</h1>
                     {{#if custom_excerpt}}
@@ -25,7 +25,7 @@
                     </figure>
                 {{/if}}
             {{/if}}
-            <section class="gh-content">
+            <section class="gh-content wrapper--ticks">
                 {{content}}
             </section>
         </article>

--- a/themes/monoliquid/partials/post-card.hbs
+++ b/themes/monoliquid/partials/post-card.hbs
@@ -1,4 +1,4 @@
-<article class="post-card {{post_class}}">
+<article class="post-card tick-right {{post_class}}">
     <a class="post-card__media" href="{{url}}" aria-label="{{title}}">
         {{#if feature_image}}
             <img

--- a/themes/monoliquid/partials/site-footer.hbs
+++ b/themes/monoliquid/partials/site-footer.hbs
@@ -1,4 +1,4 @@
-<footer class="site-footer">
+<footer class="site-footer wrapper--ticks">
     <div>
         <a class="site-footer__brand" href="{{@site.url}}">{{@site.title}}</a>
         <p>Quiet notes on code, product, and decision making.</p>

--- a/themes/monoliquid/partials/site-header.hbs
+++ b/themes/monoliquid/partials/site-header.hbs
@@ -1,5 +1,5 @@
 <header class="site-header">
-    <nav class="site-nav" aria-label="Main navigation">
+    <nav class="site-nav wrapper--ticks" aria-label="Main navigation">
         <a class="site-brand" href="{{@site.url}}">
             {{#if @site.logo}}
                 <img src="{{@site.logo}}" alt="{{@site.title}}">

--- a/themes/monoliquid/post.hbs
+++ b/themes/monoliquid/post.hbs
@@ -3,7 +3,7 @@
 <main class="site-main">
     {{#post}}
         <article class="article {{post_class}}">
-            <header class="article-header">
+            <header class="article-header wrapper--ticks">
                 <div class="article-header__meta">
                     {{#primary_tag}}
                         <a href="{{url}}">{{name}}</a>
@@ -35,11 +35,11 @@
                 <div class="article-metal" aria-hidden="true"></div>
             {{/if}}
 
-            <section class="gh-content gh-content--with-footer">
+            <section class="gh-content gh-content--with-footer wrapper--ticks">
                 {{content}}
             </section>
 
-            <footer class="article-footer">
+            <footer class="article-footer wrapper--ticks">
                 <div class="tag-row">
                     {{#foreach tags}}
                         <a href="{{url}}">{{name}}</a>

--- a/themes/monoliquid/tag.hbs
+++ b/themes/monoliquid/tag.hbs
@@ -11,7 +11,7 @@
         {{/tag}}
     </section>
 
-    <div class="post-grid">
+    <div class="post-grid wrapper--ticks">
         {{#foreach posts}}
             {{> "post-card"}}
         {{/foreach}}


### PR DESCRIPTION
### Motivation
- Introduce subtle decorative tick/chevron accents to UI panels and cards to strengthen the theme's visual language.
- Improve contrast and surface detail by adjusting hairline colors, background grid opacity, and stroke color for borders.
- Refine spacing and radii for a tighter, more consistent layout and add a metal pattern to primary buttons for texture.

### Description
- Adjusted CSS design tokens: changed `--color-hairline`, `--color-soft-hairline`, added `--color-stroke`, and reduced radii (`--radius-sm`, `--radius-md`, `--radius-base`, `--radius-lg`) and switched `--border-panel` to use `--color-hairline`.
- Tweaked page chrome: increased `body::before` opacity and grid size, updated panel background grid colors and sizes, reduced `site-main` and `site-footer` paddings, and minor margin tweaks for footer text.
- Added decorative classes and styles: new `.wrapper--ticks` and `.tick-right` with `::after` triangles, and applied those classes across templates (`index.hbs`, `author.hbs`, `page.hbs`, `post.hbs`, `tag.hbs`, `partials/*`) to enable tick accents on hero, headers, post-grid, footer, nav, and content areas.
- Added a repeating metal pattern to `.button--primary` and `.button--small` using a `pattern-marquee` keyframe animation and included a `prefers-reduced-motion` rule to disable the animation.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bd4896018832c8dd16cdb38f349f7)