### PR TITLE
[codex] Refine Monoliquid blog theme

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,13 +10,12 @@ GHOST_CONTENT_DIR=./content
 # invitations, password resets, member sign-in links, or member signup emails.
 GHOST_MAIL_TRANSPORT=Direct
 
-# SMTP example. These lower-case keys are Ghost's native nested config names and
-# are passed through by docker-compose.yml's env_file entry. Uncomment
+# Resend SMTP example. These lower-case keys are Ghost's native nested config
+# names and are passed through by docker-compose.yml's env_file entry. Uncomment
 # and replace the values when switching GHOST_MAIL_TRANSPORT to SMTP.
 # mail__from='dohyeon.kr <noreply@blog.dohyeon.kr>'
-# mail__options__service=Mailgun
-# mail__options__host=smtp.mailgun.org
+# mail__options__host=smtp.resend.com
 # mail__options__port=465
 # mail__options__secure=true
-# mail__options__auth__user=postmaster@example.mailgun.org
-# mail__options__auth__pass=replace-me
+# mail__options__auth__user=resend
+# mail__options__auth__pass=re_replace_with_resend_api_key

--- a/README.md
+++ b/README.md
@@ -59,12 +59,11 @@ encrypting it with SOPS:
 ```dotenv
 GHOST_MAIL_TRANSPORT=SMTP
 mail__from='dohyeon.kr <noreply@blog.dohyeon.kr>'
-mail__options__service=Mailgun
-mail__options__host=smtp.mailgun.org
+mail__options__host=smtp.resend.com
 mail__options__port=465
 mail__options__secure=true
-mail__options__auth__user=postmaster@example.mailgun.org
-mail__options__auth__pass=replace-me
+mail__options__auth__user=resend
+mail__options__auth__pass=re_replace_with_resend_api_key
 ```
 
 `GHOST_MAIL_TRANSPORT=Direct` is only a bootstrap/default value. Most cloud

--- a/secrets/ghost.env.enc
+++ b/secrets/ghost.env.enc
@@ -1,17 +1,23 @@
-GHOST_URL=ENC[AES256_GCM,data:xTeOq2A449CxK4Dkc+SlK3HUNOBeidY=,iv:2UMXlSrqGNojPMq04P6gTzfzLMWYK8+1ebSZz83WJkk=,tag:+lH8P2l3exrgygdltL1vQg==,type:str]
-GHOST_PORT=ENC[AES256_GCM,data:4Gcb2g==,iv:uDj58mj8PrDJCwbXobpoj4kXIe3/ZCC9hENvN6yeXlg=,tag:QvfPUfC825yN4oGG5SMJNA==,type:str]
-#ENC[AES256_GCM,data:m0DuK/oKs1oNJY+w70UxnWGAntww11wxtJS0uCv7yDML2wS09kntR0n3c9t8qE6AT1JeqYjOteXVM1raVRTQ00W/7efchzLJjt6WAX4=,iv:NeeZfyQKqr6CKslhzX8hZKe0FtDnZrRKPFsRGMeg9BQ=,tag:dDo3+CgnwoG5AdykJW5t7Q==,type:comment]
-#ENC[AES256_GCM,data:Gm1rbUwJ9JmJH2sxFoiHqACT7NRiYnGeAx2Mp5zs7ouhUMbGbHqtUJqXJKug,iv:iD952wb61KbxgcRHII8UauVCsjl+ozW/KVldAMavGz4=,tag:mDw8vLmOXD7P1LVm1y/uhQ==,type:comment]
-GHOST_NODE_ENV=ENC[AES256_GCM,data:8H4fe9GD9r35gpk=,iv:dp2xKyqPVgnCFxYf7+bWseYg/9iqziDHv6F4DF5Yk1Y=,tag:EdnIQd3whiv4gUqaWPQzQg==,type:str]
-GHOST_CONTENT_DIR=ENC[AES256_GCM,data:WJ89BNaXW4Gp,iv:CKrrnMO9qlr7z+JSz3OLctgRmoSMeonX55jV3QdpMLM=,tag:TUFuFghObhij4acHnjU4Ew==,type:str]
-#ENC[AES256_GCM,data:Y2AZ+xgqV21tyGzWPcCCQ9/saOjQcq522EdznqBnVQNoPv4u2mn7mRFFgioNasTsVRFfaCrIrwm1XzDP8tMZM4Yw9iRa+XtfNBnmtRHr,iv:Bl6jmgnuXrTNb4g4w2tamtrvBhU9wxQyPA5k4iyIjwk=,tag:Iev6LNbYepQnmZsS9mKKLA==,type:comment]
-#ENC[AES256_GCM,data:cwNpctxNeErCoOkVgrx1vNBcG8V80Z1BmH+pYy8b3lZELjQRbP3kbe+4vHI6NVc=,iv:Ir87XqRf3WXXUMl5XRC/fLzUBjRL8cXbYvRT7xT2rT4=,tag:8scrnN/LvR1ls0oW7keMag==,type:comment]
-GHOST_MAIL_TRANSPORT=ENC[AES256_GCM,data:MNmRTSLw,iv:8K4pYm7Ql2ovnnLupeF5X86EtfpcmeFWz27cUwVTub8=,tag:3xnVz4JNL61qE/xXJBz2Mg==,type:str]
-sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmQy9scGhqMFpZc0lXZ0Zp\nS2ZPNG9ReEFPRUdIT2N3MGVmdmQ1MlBwSHhzCk5pL0txblB2dU56RUVSc0NYbDlG\nUzNjUkl4aXR5M25iYXNTMkk0ZUF1MlUKLS0tIDFId1k3c1N3WDQxYkQ4elZ4Ty91\nbWliVEdONHY5Vm1wQVYvUVJZbk94VkEKEW95GNlRFeC/CFez2IHx4Uq8UoQ+49sG\nyLgXdGGp63UVd1XoHNwHj8o9WeQo2TBFWrlEVkVFsGVzrrbc2cfNdg==\n-----END AGE ENCRYPTED FILE-----\n
+GHOST_URL=ENC[AES256_GCM,data:Nx+VpRp5tlK0atLhuGpv0iDa9rH0EuE=,iv:BzGBU5gTL9xYnwM9NhYhgWw+uUsm+aXtTp9QeTYHyIw=,tag:CZ67Sp2Jvs2x3xM//5ju1g==,type:str]
+GHOST_PORT=ENC[AES256_GCM,data:42FfHw==,iv:BKh7mXYOw4QyuVlu+lpMo5HoX1KupLC4n3MtutpVCe4=,tag:9E2Rm6JrL2kOMTSpK9Ua7A==,type:str]
+#ENC[AES256_GCM,data:J6EzH0zoYdtt/avMyIslyRnNDXah0IVqudttEUkjplot06Hv38g1iFYdkFVSJiuZomONWEPl64Clwx8w3foaNnr7VFq9W6aJdaRnNqw=,iv:8t12UiLKmqBG+R0DipsoguHm0l8Vuu4CVq2Ou4CT7xI=,tag:2tL0lAoT8faYBWL2obb5oQ==,type:comment]
+#ENC[AES256_GCM,data:SPTv/jdzBwh1TYPoztDQacsTkU6S4Eu/hX0ROfoXIpxjk7IE7FfUhRF21p84,iv:8EMLHwvGQsYHWSfizSRHQyTdmyyJR+qiNxrWbl0zBQc=,tag:iL1cDCVVuJt8XxOZ+nVrfw==,type:comment]
+GHOST_NODE_ENV=ENC[AES256_GCM,data:UNf83wVwOa4nId4=,iv:6dla37RDLG6SogNCcxqejwfFTMJj3ocSvWOU5wEMbwo=,tag:7SdI0P+B6/QNbOfjKd+ugg==,type:str]
+GHOST_CONTENT_DIR=ENC[AES256_GCM,data:Zy33CALMjOPR,iv:SDi3ynLBHACTEujSGC1rdI7T3yda2vXkwrq7CWYBYDk=,tag:zVMED+Aqi2veMbVsKZbfZg==,type:str]
+#ENC[AES256_GCM,data:AtiOt1uInbZkUR3XwAYksg/M0+Xclb7e3/d9N+LyJiWFtI9gvUGAWKxoB5FQQiQZ6h7BZUmhLGa7VY7tpGywzzFOH2NTy76BuBONWiWM,iv:pCb0VU86bRs+IBA6arY4OinZoCrGYU5IvVFhNDw3lzs=,tag:3cYxwWbjkMbIkhkpew6PbA==,type:comment]
+#ENC[AES256_GCM,data:ycOm3hAfEFvH3oH62qnd47j4vX2BKRxcj5648JKNpJLCfVfCRWknQ9/ySNOa+aA=,iv:uUf+xBT8aymYky6rWuE4t5SPBaMdHoRaXceZrfi1fOM=,tag:SFSH3pHi0YRkz26sdDDZlA==,type:comment]
+GHOST_MAIL_TRANSPORT=ENC[AES256_GCM,data:6FuDrA==,iv:YRwmJ7h1YrNOaAl44Gxwivsyv3UM1jPEomjh7npfNYk=,tag:Sj43VSvUSeEvIXmCr7zvXg==,type:str]
+mail__from=ENC[AES256_GCM,data:l63TgSf8mDzvwzdJjkvadL9TqS1ssWTovXe668/MCTKSWBiaF6U=,iv:Tf6IR5C8zgg94PjJUEmq3uVK/A5VmqH/JGqwsCJmoI8=,tag:uRmAhNoT/6HMZro/6fFBqw==,type:str]
+mail__options__host=ENC[AES256_GCM,data:QFLoYnKwigNVeY82i44I,iv:eZfMwRs1ogU/Ll2pUL3t+k4zCiscva6zoraFEWCR8YM=,tag:8GVD/9Z3ax62zDPSGQwSpQ==,type:str]
+mail__options__port=ENC[AES256_GCM,data:e+Du,iv:EwglBFkoql3Ejkr1bPbNsUGa//cKvfnsZVNynLZcecY=,tag:F2B15e9+KodmXb8XXIegKg==,type:str]
+mail__options__secure=ENC[AES256_GCM,data:IIE9JQ==,iv:zoWMbuMB4ADsAgaGhRihAO67fYw336e8dqgjXBl5+Bs=,tag:960pCZ5kwHBFic4l2Jyo3A==,type:str]
+mail__options__auth__user=ENC[AES256_GCM,data:L/xzg1oH,iv:L+lmYHVaWjX6+6a9U670F2VEbi/8GIojClNG31AjrOU=,tag:TfNXU0Dko26jCCxhO6CaFA==,type:str]
+mail__options__auth__pass=ENC[AES256_GCM,data:vfvPWXddJPYVnNHAAfQtmPI/K0X0y22dGnm9CZAnhqKA9vTY,iv:atgOXv7GouHe4MfrPV2O9yVSaH8pxzOdltofHi6eLQc=,tag:smDjaA5BwEZScoHjU1QaIg==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4QlczaURWaWM3MWJnUExB\nOVlOZ2Z4aTJOR0gyUGdOenhMbm4rT20xb1ZFCk9COU5LM3F2OXkweFZQeGtFcWhC\nK0YwN0ZGbUkxcy9EMHNJWXRJcXE0cTAKLS0tIEpTQTRuM3hnNUtFYXBHNU5XRUgx\nbU9RLy9ZQXgxZ3Iwa0JGY2tYMC9KSzgKdFFF5rjLAXQyYtYOWfc0B7Mesig+vFL0\nreQx8KOdnrxrOZZjk9f5Zwi+sj6Bk8RBhyA/vB90of9k9p1p1faePg==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1lcgsswm7ycfpnlwyul6yh4g84l6lwhmwzehu5sxfhs06vdnjusxqma938u
-sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLSGxSWGd0NXJtVy9LQmNX\naWZIQklwekVyc01TdmxMc3NNQVdmRVU5a0hVCmRUT3grNG1pdis2cEpPZUh2VVh4\naG9wazViNEUrUGEzYzJ1Qm9UNGpYUmMKLS0tIGsxVTZhUWdFTVpXbFI0c3p3Z1Nl\nYXo1ME80Y0F1Rys2dGRiZlVYL1FLZm8K56RsPSnLP7GnIVDNtgj9FBPWWoj5wox/\nbtX2ngpiS8qfKJoIU8+/3WBuPH2xSPQOsn4ZVjcuTGpR5vt65HvuAg==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMSXZVZkF2ZDBBMHFMSjMw\ncGtWT2s0YUM4dVJUVnIvVHZNbDMweDByKzN3CjZMYWJiVVpQaXlEWTJRUGZjZ0N5\nUUdRS3JsOVhhdGt0eUZiNmFrMGZKdVUKLS0tIHRaS0tZNFhSWUt1ZEE1a05rSjJO\nVVJyRVBnbzFLSkdOYm1QWksyeUROQVEKl+2KDz+5NWTMcwCOBzljpF/fCbPq5cou\nVK/GGK8JRX3AJrvqdUagYvcgfsBTo7HOECawdmH2zwQFvhWOG3As+w==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_1__map_recipient=age1tqhqpn77enh2nskt7flkzah8eanmtsg2m7ef3wvm2gkul30h7ausf2mhy2
-sops_lastmodified=2026-06-07T15:25:33Z
-sops_mac=ENC[AES256_GCM,data:o3J/75mFFoVJecqVwVKDrAu0CeSSbTKnj2ox0mAM3qvnYsc7jiI28Bg4sGWAVMiSMajWoIMGy9wl1ctDfBB/BZqXDJNHTOE+zIHWGEtQSJu2LHor5AQ7b6ke3aV1IkGDmWxIPxpsvJfcJdhBUH6sp49FaP+XcuqtSf5X7EM19lI=,iv:xKHyUrWOAFVsEuQ37X0ntj3efq55w/Tzp+ZB7rFNPqU=,tag:HT9UxkMjFs0pR/llYjKUKA==,type:str]
+sops_lastmodified=2026-06-13T12:32:08Z
+sops_mac=ENC[AES256_GCM,data:d0dAiGSzdzNXKgYdb5qdszi8owLA6iJHsX4qgyfNdKYxJKyAd/wSK1gHIO+efMD+Ip+g0PgeK78PYSro5bRrqE/g+E8ae+WXzUnq6Rw6GQQK6WKtoxkXSiAc/m4ksN1FMCWThqrAcByElbBs/yzu2lhardodgGO8A7ksEkobGOs=,iv:iNYo9JLvJBWHunDzgCADjb7qC/1BWRtZJUEv7hZxQTI=,tag:jtSiYyPmy6aOLprnsZ5K7w==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.13.1

--- a/themes/monoliquid/assets/css/screen.css
+++ b/themes/monoliquid/assets/css/screen.css
@@ -764,7 +764,7 @@ button:focus-visible {
   margin-bottom: 0;
   padding: 18px;
   border: 1px solid var(--color-frame);
-  background: var(--color-metal);
+  background: var(--color-paper);
 }
 
 .article-header h1 {
@@ -826,6 +826,13 @@ button:focus-visible {
 
 .gh-content--with-footer {
   border-bottom: 0;
+}
+
+.article-comments {
+  padding: 24px 18px;
+  border: 1px solid var(--color-frame);
+  border-top: 0;
+  background: var(--color-canvas);
 }
 
 .gh-content > * {

--- a/themes/monoliquid/post.hbs
+++ b/themes/monoliquid/post.hbs
@@ -42,6 +42,10 @@
                 {{content}}
             </section>
 
+            <section class="article-comments">
+                {{comments}}
+            </section>
+
             <footer class="article-footer wrapper--ticks">
                 <div class="tag-row">
                     {{#foreach tags}}


### PR DESCRIPTION
## Summary
- Redesigns the Monoliquid Ghost theme around mono/liquid/metal blog styling
- Reworks home, archive, article, footer, and newsletter surfaces
- Adds post-list ticks, patterned latest marquee, self-hosted Archivo/Pretendard fonts, and comments support
- Documents Resend SMTP settings and updates encrypted Ghost mail settings

## Verification
- Checked local Ghost pages for home, tag archive, and post rendering
- Verified comments_enabled=all locally and on production
- Verified self-hosted fonts and latest/comment HTML render locally
