### PR TITLE
[codex] Finalize Monoliquid theme and mail fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ mail__options__auth__user=resend
 mail__options__auth__pass=re_replace_with_resend_api_key
 ```
 
+Until `blog.dohyeon.kr` is verified in Resend, use Resend's default sender as a
+temporary admin-login fallback:
+
+```dotenv
+mail__from='dohyeon.kr <onboarding@resend.dev>'
+```
+
+After the DNS records below verify, switch `mail__from` back to the branded
+sender:
+
+```dotenv
+mail__from='dohyeon.kr <noreply@blog.dohyeon.kr>'
+```
+
 `GHOST_MAIL_TRANSPORT=Direct` is only a bootstrap/default value. Most cloud
 servers block or rate-limit direct outbound mail, and direct mail has poor
 deliverability without SMTP-provider reputation, SPF, DKIM, and DMARC.

--- a/secrets/ghost.env.enc
+++ b/secrets/ghost.env.enc
@@ -1,23 +1,23 @@
-GHOST_URL=ENC[AES256_GCM,data:Nx+VpRp5tlK0atLhuGpv0iDa9rH0EuE=,iv:BzGBU5gTL9xYnwM9NhYhgWw+uUsm+aXtTp9QeTYHyIw=,tag:CZ67Sp2Jvs2x3xM//5ju1g==,type:str]
-GHOST_PORT=ENC[AES256_GCM,data:42FfHw==,iv:BKh7mXYOw4QyuVlu+lpMo5HoX1KupLC4n3MtutpVCe4=,tag:9E2Rm6JrL2kOMTSpK9Ua7A==,type:str]
-#ENC[AES256_GCM,data:J6EzH0zoYdtt/avMyIslyRnNDXah0IVqudttEUkjplot06Hv38g1iFYdkFVSJiuZomONWEPl64Clwx8w3foaNnr7VFq9W6aJdaRnNqw=,iv:8t12UiLKmqBG+R0DipsoguHm0l8Vuu4CVq2Ou4CT7xI=,tag:2tL0lAoT8faYBWL2obb5oQ==,type:comment]
-#ENC[AES256_GCM,data:SPTv/jdzBwh1TYPoztDQacsTkU6S4Eu/hX0ROfoXIpxjk7IE7FfUhRF21p84,iv:8EMLHwvGQsYHWSfizSRHQyTdmyyJR+qiNxrWbl0zBQc=,tag:iL1cDCVVuJt8XxOZ+nVrfw==,type:comment]
-GHOST_NODE_ENV=ENC[AES256_GCM,data:UNf83wVwOa4nId4=,iv:6dla37RDLG6SogNCcxqejwfFTMJj3ocSvWOU5wEMbwo=,tag:7SdI0P+B6/QNbOfjKd+ugg==,type:str]
-GHOST_CONTENT_DIR=ENC[AES256_GCM,data:Zy33CALMjOPR,iv:SDi3ynLBHACTEujSGC1rdI7T3yda2vXkwrq7CWYBYDk=,tag:zVMED+Aqi2veMbVsKZbfZg==,type:str]
-#ENC[AES256_GCM,data:AtiOt1uInbZkUR3XwAYksg/M0+Xclb7e3/d9N+LyJiWFtI9gvUGAWKxoB5FQQiQZ6h7BZUmhLGa7VY7tpGywzzFOH2NTy76BuBONWiWM,iv:pCb0VU86bRs+IBA6arY4OinZoCrGYU5IvVFhNDw3lzs=,tag:3cYxwWbjkMbIkhkpew6PbA==,type:comment]
-#ENC[AES256_GCM,data:ycOm3hAfEFvH3oH62qnd47j4vX2BKRxcj5648JKNpJLCfVfCRWknQ9/ySNOa+aA=,iv:uUf+xBT8aymYky6rWuE4t5SPBaMdHoRaXceZrfi1fOM=,tag:SFSH3pHi0YRkz26sdDDZlA==,type:comment]
-GHOST_MAIL_TRANSPORT=ENC[AES256_GCM,data:6FuDrA==,iv:YRwmJ7h1YrNOaAl44Gxwivsyv3UM1jPEomjh7npfNYk=,tag:Sj43VSvUSeEvIXmCr7zvXg==,type:str]
-mail__from=ENC[AES256_GCM,data:l63TgSf8mDzvwzdJjkvadL9TqS1ssWTovXe668/MCTKSWBiaF6U=,iv:Tf6IR5C8zgg94PjJUEmq3uVK/A5VmqH/JGqwsCJmoI8=,tag:uRmAhNoT/6HMZro/6fFBqw==,type:str]
-mail__options__host=ENC[AES256_GCM,data:QFLoYnKwigNVeY82i44I,iv:eZfMwRs1ogU/Ll2pUL3t+k4zCiscva6zoraFEWCR8YM=,tag:8GVD/9Z3ax62zDPSGQwSpQ==,type:str]
-mail__options__port=ENC[AES256_GCM,data:e+Du,iv:EwglBFkoql3Ejkr1bPbNsUGa//cKvfnsZVNynLZcecY=,tag:F2B15e9+KodmXb8XXIegKg==,type:str]
-mail__options__secure=ENC[AES256_GCM,data:IIE9JQ==,iv:zoWMbuMB4ADsAgaGhRihAO67fYw336e8dqgjXBl5+Bs=,tag:960pCZ5kwHBFic4l2Jyo3A==,type:str]
-mail__options__auth__user=ENC[AES256_GCM,data:L/xzg1oH,iv:L+lmYHVaWjX6+6a9U670F2VEbi/8GIojClNG31AjrOU=,tag:TfNXU0Dko26jCCxhO6CaFA==,type:str]
-mail__options__auth__pass=ENC[AES256_GCM,data:vfvPWXddJPYVnNHAAfQtmPI/K0X0y22dGnm9CZAnhqKA9vTY,iv:atgOXv7GouHe4MfrPV2O9yVSaH8pxzOdltofHi6eLQc=,tag:smDjaA5BwEZScoHjU1QaIg==,type:str]
-sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4QlczaURWaWM3MWJnUExB\nOVlOZ2Z4aTJOR0gyUGdOenhMbm4rT20xb1ZFCk9COU5LM3F2OXkweFZQeGtFcWhC\nK0YwN0ZGbUkxcy9EMHNJWXRJcXE0cTAKLS0tIEpTQTRuM3hnNUtFYXBHNU5XRUgx\nbU9RLy9ZQXgxZ3Iwa0JGY2tYMC9KSzgKdFFF5rjLAXQyYtYOWfc0B7Mesig+vFL0\nreQx8KOdnrxrOZZjk9f5Zwi+sj6Bk8RBhyA/vB90of9k9p1p1faePg==\n-----END AGE ENCRYPTED FILE-----\n
+GHOST_URL=ENC[AES256_GCM,data:eShTis5UsdvFC6xtj+EPqRav6kdQ018=,iv:HNmcvo3T2WKDaJXPK8qBxUYKoVGtXAlCXZq7rIbbNGo=,tag:T/YQ8++pq8ejV26sqZwfhg==,type:str]
+GHOST_PORT=ENC[AES256_GCM,data:2g1Qew==,iv:iOGsHfQNxQS+0GnqR5cBm3Q0II6d8Q1yl+/jiFBLqbo=,tag:C5ME0IBIXuO4WmHthsBJnw==,type:str]
+#ENC[AES256_GCM,data:jtMIczo9aTJNIuiz9jaRGTK1+LYrTDvugTw/zNt7t62zM6sRlE1CdsaCIR8lrcwa85TgB/n29ucDI5kSNNfMEEZ93bAYjX007Xi852Q=,iv:a8rIiz0CMVg+nNrKZBg4UuhzNsdEnrBr5qp9KGhPInk=,tag:fA2E+Qmu/mA9rZe6pFa7ww==,type:comment]
+#ENC[AES256_GCM,data:SgaouIRxMv1vtIBLcuRKgqp3l+ynEdUqnsgqzbejKisEu5EBOYpcKvqxUYN6,iv:V/8yjKSUGZddZoxeBvIAcnb/SSI0MHCy2m6LUZwfEWs=,tag:p4MD2pI4Q9ub0JCk64asQg==,type:comment]
+GHOST_NODE_ENV=ENC[AES256_GCM,data:1pHAOezADw/FqlM=,iv:bd940kWSwcIVsZ/3CimAwT+CvOdrDRAklg7QaQiR3k4=,tag:A6MDmJxsHbq26Vncy6byQA==,type:str]
+GHOST_CONTENT_DIR=ENC[AES256_GCM,data:30cp9LZA/H/j,iv:1gK4qKXQlmIxWyUbmpzkeNrRyl0jVdhoKImPsk2l3Hg=,tag:OcZAxgFWB40fSiF+/DCJFw==,type:str]
+#ENC[AES256_GCM,data:Mo+QmN/zbz1g5pTAHsTLV0fgpABYOLEe6hjhN5jzIuref8SyFAZXqhfHrJMiR7k6cmjtLtI4Ohbeo/sfs0i+fcNhrpSyveyMYUg/pCad,iv:NX1Rs2ZVaafw69YVpQbMxoH8l9cd6YUIjzW0pVblsIk=,tag:02Avhj/7QJmrj3T+DKFGzg==,type:comment]
+#ENC[AES256_GCM,data:0zwK9SL6YvZO879kE2nuUQ5kS2rzUYew5zURsd2U57RL48WuOHxPVDEsYPIls7w=,iv:YrWwJx9zDJkFl06/RlIJN3ZW0g5QnyraiYC1pg1255A=,tag:cTNYN8koeQGmAl5AHC+y7w==,type:comment]
+GHOST_MAIL_TRANSPORT=ENC[AES256_GCM,data:1iaDbA==,iv:hb7OPr4TsJCwj8uzxHX7Hl7dvP+uMhnQpuNrF38dYdQ=,tag:Wt/PqTrn7XiCtYZB9oS8og==,type:str]
+mail__from=ENC[AES256_GCM,data:eeTHTTSJwVHqXWIwPLpSOwzZ0O/NQnfakdj8P5+9ypPr0peQ,iv:FvrdPUtd8qBvY3Ht7dBt+8nlXIGcplZtcMikXW5IUxo=,tag:fNgpA3KfWA5IJHO6/M2vHw==,type:str]
+mail__options__host=ENC[AES256_GCM,data:1CDMuZlC80HmAfjfsixx,iv:fph7CnvTPBkAE4h7txcX8HVGRJca7+8nFDB/tymj2IQ=,tag:Dmav6Ox9fsdV9nwEUi4R2Q==,type:str]
+mail__options__port=ENC[AES256_GCM,data:kuhE,iv:NdIaoyfkV2XXhJQfpGv6g0pcdgRH/05VGZQzNx7FuYs=,tag:YBhscwoOI9LAgxamZXFb/w==,type:str]
+mail__options__secure=ENC[AES256_GCM,data:B3CQng==,iv:oNxibwFNdWMjxvlaQpIXS3Q5ghKKywFZdEL5vYNgdNE=,tag:5GPLP4/DGkxNux2DaGbKxw==,type:str]
+mail__options__auth__user=ENC[AES256_GCM,data:Ry4ExLsu,iv:AxwDQDN6PpO7UY+N3K+zg2Z/+4+50Fk8C60SV/IZ2Hk=,tag:h0mgsmbCNl8DPqbb/dJGww==,type:str]
+mail__options__auth__pass=ENC[AES256_GCM,data:weFwvh/pR9RF8C91TzE+roXbSY1JcGcO8JdfglR8NNV2yhrA,iv:0Y/LyEALKC5H4rMZiI/SsXtH6/6QlX70Kv4moelvRHg=,tag:WrPMz8eNsaJgdnSMx8tnww==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrS3JYTVB0WGRhMDN5OEE3\nSjAwOFBJaitjcFhPT1lVRmlDVGhYYjRuV2w4Cm5VQU5nSk0wTWxWNnBaZDBpYlNw\ncjNGSXh5UTJDMVB6dGlUYy9nQkhXSjgKLS0tIG5HOWQrRVJ1WTdMaDFBUmRCU0hQ\nTEpHMEFFMjNxaElCbzZXOVZGZmZqN28KD3rbYtM+erOzHOJHKn7BLiZExWfu3Hiy\nfQrheCULx/LRCNPeq/iOlQUKBHO1O2CPhUR+KQFa9GAz0VU1ND2Z0Q==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1lcgsswm7ycfpnlwyul6yh4g84l6lwhmwzehu5sxfhs06vdnjusxqma938u
-sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMSXZVZkF2ZDBBMHFMSjMw\ncGtWT2s0YUM4dVJUVnIvVHZNbDMweDByKzN3CjZMYWJiVVpQaXlEWTJRUGZjZ0N5\nUUdRS3JsOVhhdGt0eUZiNmFrMGZKdVUKLS0tIHRaS0tZNFhSWUt1ZEE1a05rSjJO\nVVJyRVBnbzFLSkdOYm1QWksyeUROQVEKl+2KDz+5NWTMcwCOBzljpF/fCbPq5cou\nVK/GGK8JRX3AJrvqdUagYvcgfsBTo7HOECawdmH2zwQFvhWOG3As+w==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkV1FsTTIwZDE2VHhTZzVF\ncUlXMG1tY0lQSDg1R2dzSXAwS21SRHNyRGp3CnJ0TkV1bkFqTkdkekI2dlAra3ZC\neDR1TnlMVW9FRkRzcU1KKzVWV1ZrQmsKLS0tIGlOL0hMVXduMDYrRytreUxxamFV\nMnkyR2xYa0doRFE0eDN1UmZoNWVndGcKCu9Fee13qmxjn1M06l7pIrHGsYkoQLmp\nBfYYD9ioirdQC8+phYN73ez9rmuJsF0fTGWpiaC+4Dxl3V5VpL1QYA==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_1__map_recipient=age1tqhqpn77enh2nskt7flkzah8eanmtsg2m7ef3wvm2gkul30h7ausf2mhy2
-sops_lastmodified=2026-06-13T12:32:08Z
-sops_mac=ENC[AES256_GCM,data:d0dAiGSzdzNXKgYdb5qdszi8owLA6iJHsX4qgyfNdKYxJKyAd/wSK1gHIO+efMD+Ip+g0PgeK78PYSro5bRrqE/g+E8ae+WXzUnq6Rw6GQQK6WKtoxkXSiAc/m4ksN1FMCWThqrAcByElbBs/yzu2lhardodgGO8A7ksEkobGOs=,iv:iNYo9JLvJBWHunDzgCADjb7qC/1BWRtZJUEv7hZxQTI=,tag:jtSiYyPmy6aOLprnsZ5K7w==,type:str]
+sops_lastmodified=2026-06-13T13:28:08Z
+sops_mac=ENC[AES256_GCM,data:63wy20QrMwSXCQx/+3cJ65LkUAmERV+1WuUS6UtA8VJuHoLq3j4B2sHUe8c76hr+xAKGbIUO0nLHRJ05tNy7PrgmLywYTXjqKUHl62wS8/bsCBM2cDYguGyZVlY97vUpdvgiw+CSoJjDyDazXPNjpa+QUWiB+60yaL4AioOHzKA=,iv:D8YDPjhl8I4NVP66iJKv5veMYTdUABn+AG5WwC3W9do=,tag:NplMdt6SOPATTx/MhEStcQ==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.13.1


### PR DESCRIPTION
## Summary
- Redesign the Ghost theme around the mono/liquid/metal IT blog direction
- Unify archive and post list styling, add post comments, and refine tick/border treatments
- Configure Resend SMTP docs and encrypted Ghost env with a temporary onboarding@resend.dev fallback until blog.dohyeon.kr DNS verification completes

## Verification
- Checked Ghost Admin in cmux browser: sign-in now reaches the verification-code screen instead of the mail configuration error
- Clicked Resend in the verification screen; no failure message appeared and Ghost logs show /ghost/api/admin/session/verify returning 200
- Confirmed PR branch head is dd3d999

## Follow-up
- Add the required Resend DKIM/SPF/MX records in Gabia for blog.dohyeon.kr, then switch mail__from back to noreply@blog.dohyeon.kr