### PR TITLE
fix: restore branded Resend sender

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Agent Notes
+
+## Release Commit Messages
+
+This repository uses `semantic-release` with the default conventional commit
+analyzer. Deployment can run without a GitHub Release, but a new release is only
+created when at least one commit since the previous tag has a release-triggering
+commit header.
+
+Use Conventional Commits for any change that should create a release:
+
+- `fix: ...` for a patch release.
+- `feat: ...` for a minor release.
+- `feat!: ...`, `fix!: ...`, or a `BREAKING CHANGE:` footer for a major release.
+
+Do not rely on a PR title alone. If GitHub creates a merge commit like
+`Merge pull request #...`, semantic-release may analyze that merge header and the
+branch commits; non-conventional branch commits such as `Restore branded Resend
+sender` will not trigger a release.
+
+When preparing a release-relevant PR, make sure the actual commit message first
+line is conventional, for example:
+
+```text
+fix: restore branded Resend sender
+```
+
+For documentation-only or maintenance changes that should not publish a release,
+use non-release types such as `docs:` or `chore:`.

--- a/README.md
+++ b/README.md
@@ -66,20 +66,6 @@ mail__options__auth__user=resend
 mail__options__auth__pass=re_replace_with_resend_api_key
 ```
 
-Until `blog.dohyeon.kr` is verified in Resend, use Resend's default sender as a
-temporary admin-login fallback:
-
-```dotenv
-mail__from='dohyeon.kr <onboarding@resend.dev>'
-```
-
-After the DNS records below verify, switch `mail__from` back to the branded
-sender:
-
-```dotenv
-mail__from='dohyeon.kr <noreply@blog.dohyeon.kr>'
-```
-
 `GHOST_MAIL_TRANSPORT=Direct` is only a bootstrap/default value. Most cloud
 servers block or rate-limit direct outbound mail, and direct mail has poor
 deliverability without SMTP-provider reputation, SPF, DKIM, and DMARC.

--- a/secrets/ghost.env.enc
+++ b/secrets/ghost.env.enc
@@ -1,23 +1,23 @@
-GHOST_URL=ENC[AES256_GCM,data:eShTis5UsdvFC6xtj+EPqRav6kdQ018=,iv:HNmcvo3T2WKDaJXPK8qBxUYKoVGtXAlCXZq7rIbbNGo=,tag:T/YQ8++pq8ejV26sqZwfhg==,type:str]
-GHOST_PORT=ENC[AES256_GCM,data:2g1Qew==,iv:iOGsHfQNxQS+0GnqR5cBm3Q0II6d8Q1yl+/jiFBLqbo=,tag:C5ME0IBIXuO4WmHthsBJnw==,type:str]
-#ENC[AES256_GCM,data:jtMIczo9aTJNIuiz9jaRGTK1+LYrTDvugTw/zNt7t62zM6sRlE1CdsaCIR8lrcwa85TgB/n29ucDI5kSNNfMEEZ93bAYjX007Xi852Q=,iv:a8rIiz0CMVg+nNrKZBg4UuhzNsdEnrBr5qp9KGhPInk=,tag:fA2E+Qmu/mA9rZe6pFa7ww==,type:comment]
-#ENC[AES256_GCM,data:SgaouIRxMv1vtIBLcuRKgqp3l+ynEdUqnsgqzbejKisEu5EBOYpcKvqxUYN6,iv:V/8yjKSUGZddZoxeBvIAcnb/SSI0MHCy2m6LUZwfEWs=,tag:p4MD2pI4Q9ub0JCk64asQg==,type:comment]
-GHOST_NODE_ENV=ENC[AES256_GCM,data:1pHAOezADw/FqlM=,iv:bd940kWSwcIVsZ/3CimAwT+CvOdrDRAklg7QaQiR3k4=,tag:A6MDmJxsHbq26Vncy6byQA==,type:str]
-GHOST_CONTENT_DIR=ENC[AES256_GCM,data:30cp9LZA/H/j,iv:1gK4qKXQlmIxWyUbmpzkeNrRyl0jVdhoKImPsk2l3Hg=,tag:OcZAxgFWB40fSiF+/DCJFw==,type:str]
-#ENC[AES256_GCM,data:Mo+QmN/zbz1g5pTAHsTLV0fgpABYOLEe6hjhN5jzIuref8SyFAZXqhfHrJMiR7k6cmjtLtI4Ohbeo/sfs0i+fcNhrpSyveyMYUg/pCad,iv:NX1Rs2ZVaafw69YVpQbMxoH8l9cd6YUIjzW0pVblsIk=,tag:02Avhj/7QJmrj3T+DKFGzg==,type:comment]
-#ENC[AES256_GCM,data:0zwK9SL6YvZO879kE2nuUQ5kS2rzUYew5zURsd2U57RL48WuOHxPVDEsYPIls7w=,iv:YrWwJx9zDJkFl06/RlIJN3ZW0g5QnyraiYC1pg1255A=,tag:cTNYN8koeQGmAl5AHC+y7w==,type:comment]
-GHOST_MAIL_TRANSPORT=ENC[AES256_GCM,data:1iaDbA==,iv:hb7OPr4TsJCwj8uzxHX7Hl7dvP+uMhnQpuNrF38dYdQ=,tag:Wt/PqTrn7XiCtYZB9oS8og==,type:str]
-mail__from=ENC[AES256_GCM,data:eeTHTTSJwVHqXWIwPLpSOwzZ0O/NQnfakdj8P5+9ypPr0peQ,iv:FvrdPUtd8qBvY3Ht7dBt+8nlXIGcplZtcMikXW5IUxo=,tag:fNgpA3KfWA5IJHO6/M2vHw==,type:str]
-mail__options__host=ENC[AES256_GCM,data:1CDMuZlC80HmAfjfsixx,iv:fph7CnvTPBkAE4h7txcX8HVGRJca7+8nFDB/tymj2IQ=,tag:Dmav6Ox9fsdV9nwEUi4R2Q==,type:str]
-mail__options__port=ENC[AES256_GCM,data:kuhE,iv:NdIaoyfkV2XXhJQfpGv6g0pcdgRH/05VGZQzNx7FuYs=,tag:YBhscwoOI9LAgxamZXFb/w==,type:str]
-mail__options__secure=ENC[AES256_GCM,data:B3CQng==,iv:oNxibwFNdWMjxvlaQpIXS3Q5ghKKywFZdEL5vYNgdNE=,tag:5GPLP4/DGkxNux2DaGbKxw==,type:str]
-mail__options__auth__user=ENC[AES256_GCM,data:Ry4ExLsu,iv:AxwDQDN6PpO7UY+N3K+zg2Z/+4+50Fk8C60SV/IZ2Hk=,tag:h0mgsmbCNl8DPqbb/dJGww==,type:str]
-mail__options__auth__pass=ENC[AES256_GCM,data:weFwvh/pR9RF8C91TzE+roXbSY1JcGcO8JdfglR8NNV2yhrA,iv:0Y/LyEALKC5H4rMZiI/SsXtH6/6QlX70Kv4moelvRHg=,tag:WrPMz8eNsaJgdnSMx8tnww==,type:str]
-sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrS3JYTVB0WGRhMDN5OEE3\nSjAwOFBJaitjcFhPT1lVRmlDVGhYYjRuV2w4Cm5VQU5nSk0wTWxWNnBaZDBpYlNw\ncjNGSXh5UTJDMVB6dGlUYy9nQkhXSjgKLS0tIG5HOWQrRVJ1WTdMaDFBUmRCU0hQ\nTEpHMEFFMjNxaElCbzZXOVZGZmZqN28KD3rbYtM+erOzHOJHKn7BLiZExWfu3Hiy\nfQrheCULx/LRCNPeq/iOlQUKBHO1O2CPhUR+KQFa9GAz0VU1ND2Z0Q==\n-----END AGE ENCRYPTED FILE-----\n
+GHOST_URL=ENC[AES256_GCM,data:bJTH6hUj3LGakhbtyOUmU1bHWjqUPLI=,iv:jly8uRt1/NHfXTMOgudRPHTV4aTfhfMDfoqA9bnzxLw=,tag:f/VgnVKuuQCU+2Rr5fetgA==,type:str]
+GHOST_PORT=ENC[AES256_GCM,data:wneNFw==,iv:AI4jXtCCwJ0AMoNLqKV3bqpeoSByhpMhel/kskDAB78=,tag:Vzzgmux6NVuqC7Fo/s0kPg==,type:str]
+#ENC[AES256_GCM,data:HOEAweVDj5vW1MTjpdSJ9Ize4xxtP1RUtYNERBSxa5D6tm1j+xuRvNXqay7yOj0e2r045Q+A7rQnxRDbZLjsqprl96dd6njJ+zxByK0=,iv:6JwrZRW1oPSduoueMJMKMSOftNJDh3yu7ABsADMjTAs=,tag:yErPjyFdUQz+rRVxqfpqPA==,type:comment]
+#ENC[AES256_GCM,data:TYy/VBE7oyuF2NwysQORHFBjzXCI+mrfwQF7944kyb2X4PsuQ3KjgRMYXhQ+,iv:FTbteHt+OUoYfbImB17WJ7U5I+A+5yC75IZrqrNmaQw=,tag:vwufZmjekw+HTJmyYyOVFQ==,type:comment]
+GHOST_NODE_ENV=ENC[AES256_GCM,data:lFJ9EcH8fHe8q0w=,iv:T+oRKSUuAKuPaXGoSMj9knx/jGxZDMeUUzYLiloci8U=,tag:mwYiYtboAEYUlXFUrG+JKg==,type:str]
+GHOST_CONTENT_DIR=ENC[AES256_GCM,data:gZJ+ZocbrLPa,iv:9C906XTBcFajEimpXKhyO87PDW7PrhLgsBhAOYxH0Eo=,tag:VVX8RZB4Abi2F67LlGX1nA==,type:str]
+#ENC[AES256_GCM,data:1GH/NZVIWWrAQ6WkjwwNMhFTuSUfmZ9L0ot3KLdUlin6qdjrDzlQHuMMRzXYMl6v0cf/axoJIzEC6lKFopvjKykM86+C5sgb/nyYFlTH,iv:zG+/is6sSayhjm2oltHNJz7MITt/VtfSenO0CllfKd4=,tag:CKJDwwNiCfF3vG41PzTiTQ==,type:comment]
+#ENC[AES256_GCM,data:kgIHXQmzby4QVlqIj8CVIL5ba3IQOWo0mRJKgVWAkK9cQa/eVR3Nq2oXQYb9h4U=,iv:czmZczkBOpQgs941AyoOTawAEz51DwR5n5oH9v+rCpY=,tag:uznYrEn05Fy1ZiSsziNUrg==,type:comment]
+GHOST_MAIL_TRANSPORT=ENC[AES256_GCM,data:uOUIXA==,iv:F9m0rBQLii9R7lHdqJ7J0W2x5hUYReaqkREMW/5iPng=,tag:jncynRJfYqFxZmPNwURNHA==,type:str]
+mail__from=ENC[AES256_GCM,data:usK+9+RZNWC0FFukxAAOfq7axfNK7kYn0Tpim46apl2sqLKP3ww=,iv:4WQ5gUqI1GKk3X5qGYu8CwuS1w2pc4Fui0lrnJ3paa0=,tag:atWmNw+bRRxFeaWO8LSPYQ==,type:str]
+mail__options__host=ENC[AES256_GCM,data:/rsWNVnCEhoVl8NSSpAI,iv:sCAjndOJJckYtqazntYqj+R5L457dSCWH+++/Y+TGyQ=,tag:0anPOdowOD6cGrS2e64POw==,type:str]
+mail__options__port=ENC[AES256_GCM,data:ow8J,iv:Nd+UTSXoov7TDptYSflfTPG49fKVDURa/q2fMAK3+vs=,tag:dTnKy26nNH060PfBrO042Q==,type:str]
+mail__options__secure=ENC[AES256_GCM,data:mUaCrQ==,iv:hIj7UXK5OKlZ77lYvwpSWYAZEyHpZWfaurrjj+47Ak4=,tag:4OxpJTR9AZFl3UcCZXHVSQ==,type:str]
+mail__options__auth__user=ENC[AES256_GCM,data:poAHAX0W,iv:SzKBJPRv72QmcYgc4vlz5F1vlxQoZr6jXJGu/Wi5kAA=,tag:NU7qLRIFSb8aEdWU70Y1rA==,type:str]
+mail__options__auth__pass=ENC[AES256_GCM,data:Rrh5WEpKPtakb3YRlTQSQP7jRCIAcG/tLP4yzNfoCCo3aeAB,iv:Lf2lCoxGI50FPSJ5Bpufp2JcdsJwR+xfb4nW50NWd1Q=,tag:GSXO34uVj+H/zaOfDicwIg==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3NXZ4UlBxdUhaNUJNcTdN\nMUp3c3MxcnF6aGxubWlPQ01uOE1sL21TUGxVCmMraEZ2d3RXaGt3VGpDOHptZEZM\nTmJLbUIwSDl2Q2w3azI1MXNyc2I5N0kKLS0tIFNqRGZmd3B0bWR6azJpZ1NkTmtZ\nZDQzcFJFSVlOdlNza3lsUThibDYyQXMK989cpazrc5MF5uCsTQKhTNIAV8A2mzk1\nKLTYivW29Onquz7aHfQoUpMPu0k0T19ku3oHwBbBIga9usQKiMcQnw==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1lcgsswm7ycfpnlwyul6yh4g84l6lwhmwzehu5sxfhs06vdnjusxqma938u
-sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkV1FsTTIwZDE2VHhTZzVF\ncUlXMG1tY0lQSDg1R2dzSXAwS21SRHNyRGp3CnJ0TkV1bkFqTkdkekI2dlAra3ZC\neDR1TnlMVW9FRkRzcU1KKzVWV1ZrQmsKLS0tIGlOL0hMVXduMDYrRytreUxxamFV\nMnkyR2xYa0doRFE0eDN1UmZoNWVndGcKCu9Fee13qmxjn1M06l7pIrHGsYkoQLmp\nBfYYD9ioirdQC8+phYN73ez9rmuJsF0fTGWpiaC+4Dxl3V5VpL1QYA==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvYlFVWks4TUREd3luR2lZ\nbEh2dnN3bnNaY0I5NndDeURqRGlwNHNMQXcwCk5NRE1meitHWS9qbjJaS0lFM1FB\ncjlhTm9ndGZJWWlUSjhncGVEUDJvK3MKLS0tIFV3KzdyaVVZVWQ0VXpTZ0lIZEFQ\nWm95Y2JWVGtmaTQ5MmdoM0VsRHU4MDAKxylwO/NOjL3HTQxa3skFoxMEPf/ZIn5g\nGM1LhYD422jHNgPyN+mDy/SzBU7buSmixJEhYsSMVcr0C39wUHYeww==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_1__map_recipient=age1tqhqpn77enh2nskt7flkzah8eanmtsg2m7ef3wvm2gkul30h7ausf2mhy2
-sops_lastmodified=2026-06-13T13:28:08Z
-sops_mac=ENC[AES256_GCM,data:63wy20QrMwSXCQx/+3cJ65LkUAmERV+1WuUS6UtA8VJuHoLq3j4B2sHUe8c76hr+xAKGbIUO0nLHRJ05tNy7PrgmLywYTXjqKUHl62wS8/bsCBM2cDYguGyZVlY97vUpdvgiw+CSoJjDyDazXPNjpa+QUWiB+60yaL4AioOHzKA=,iv:D8YDPjhl8I4NVP66iJKv5veMYTdUABn+AG5WwC3W9do=,tag:NplMdt6SOPATTx/MhEStcQ==,type:str]
+sops_lastmodified=2026-06-13T14:14:19Z
+sops_mac=ENC[AES256_GCM,data:fBm1tH7j0n7tw4cdlOvRvfqGohqpKf7Sb86vumkdJSl2RNGktLoUpzD8OWpdQxaWZF1TD2g0KOT2kxGg60LY8aOufX4QxcDZ7oBqvPvjV9m80y9L7yJfzfTSI0j7MfRN4mg1/cw5po0A2SfGpfsUxY7fARNNl6zQI8leFbDlU+Y=,iv:DYqgW8qc9SC71Ctc26Qsl250SMOk/eglL8wCtF3zxXk=,tag:i/BbNgKc/eIu8O2jjrkfaw==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.13.1


### PR DESCRIPTION
## Summary
- Restore Ghost mail sender to `dohyeon.kr <noreply@blog.dohyeon.kr>` after Resend domain verification
- Remove temporary onboarding@resend.dev fallback instructions from README
- Re-encrypt production Ghost env with the branded sender
- Add `AGENTS.md` guidance requiring release-relevant commits to use Conventional Commit headers

## Verification
- Confirmed Resend domain `blog.dohyeon.kr` is verified, including DKIM, MX, and SPF records
- Recreated Ghost with `mail__from=dohyeon.kr <noreply@blog.dohyeon.kr>`
- Sent a branded Resend API test email successfully

## Release note
- This PR contains a single release-triggering commit: `fix: restore branded Resend sender`.