### PR TITLE
fix: simplify header and footer copy

### DIFF
--- a/themes/monoliquid/assets/css/screen.css
+++ b/themes/monoliquid/assets/css/screen.css
@@ -219,7 +219,6 @@ button:focus-visible {
 
 .top-banner {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 12px;
   min-height: 64px;
@@ -247,18 +246,6 @@ button:focus-visible {
   filter: invert(1) grayscale(1) contrast(1.2);
 }
 
-.top-banner__line {
-  margin: 0;
-  color: var(--color-canvas);
-  font-size: 14px;
-  font-weight: 900;
-  line-height: 1.15;
-  text-align: right;
-  text-transform: uppercase;
-  white-space: nowrap;
-}
-
-.buy-sticker,
 .new-sticker {
   display: inline-flex;
   align-items: center;
@@ -278,7 +265,6 @@ button:focus-visible {
     transform 120ms var(--ease-out);
 }
 
-.buy-sticker:hover,
 .new-sticker:hover {
   background: var(--color-canvas);
   color: var(--color-ink);
@@ -1073,11 +1059,6 @@ button:focus-visible {
 
   .top-banner {
     grid-template-columns: 1fr;
-  }
-
-  .top-banner__line {
-    text-align: left;
-    white-space: normal;
   }
 
   .site-nav {

--- a/themes/monoliquid/partials/site-footer.hbs
+++ b/themes/monoliquid/partials/site-footer.hbs
@@ -1,7 +1,6 @@
 <footer class="site-footer wrapper--ticks">
     <div>
         <a class="site-footer__brand" href="{{@site.url}}">{{@site.title}}</a>
-        <p>Quiet notes on code, product, and decision making.</p>
     </div>
     <p class="site-footer__fine">&copy; {{date format="YYYY"}} {{@site.title}}</p>
 </footer>

--- a/themes/monoliquid/partials/site-header.hbs
+++ b/themes/monoliquid/partials/site-header.hbs
@@ -7,8 +7,6 @@
                 <span>{{@site.title}}</span>
             {{/if}}
         </a>
-        <p class="top-banner__line">BUILD / DEBUG / SHIP. ONLINE.</p>
-        <a class="buy-sticker" href="#posts">READ IT NOTES</a>
     </div>
 
     <nav class="site-nav" aria-label="Main navigation">


### PR DESCRIPTION
## Summary
- Remove the generic top banner line `BUILD / DEBUG / SHIP. ONLINE.`
- Remove the header `READ IT NOTES` sticker link
- Remove the generic footer description copy
- Simplify the top banner CSS and remove unused `.top-banner__line` / `.buy-sticker` styles

## Copywriting note
- Recommendation is to leave this space silent rather than add another slogan. The current visual system is stronger when the header carries the brand only.

## Verification
- Searched the theme to confirm the removed copy and removed classes are no longer referenced.