### PR TITLE
feat: add Ghost announcement marquee

### DIFF
--- a/themes/monoliquid/assets/css/screen.css
+++ b/themes/monoliquid/assets/css/screen.css
@@ -438,6 +438,15 @@ iframe[src*="announcement-bar"] {
   animation: marquee-latest 16s linear infinite;
 }
 
+.site-announcement-marquee .post-index__marquee-track {
+  animation-duration: 32s;
+}
+
+.site-announcement-marquee:hover .post-index__marquee-track,
+.site-announcement-marquee:focus-within .post-index__marquee-track {
+  animation-play-state: paused;
+}
+
 .site-announcement-marquee span,
 .post-index__marquee span {
   display: inline-block;

--- a/themes/monoliquid/assets/css/screen.css
+++ b/themes/monoliquid/assets/css/screen.css
@@ -432,6 +432,15 @@ iframe[src*="announcement-bar"] {
   color: var(--color-canvas);
 }
 
+.site-announcement-marquee {
+  cursor: pointer;
+}
+
+.site-announcement-marquee:focus-visible {
+  outline: 2px solid var(--color-canvas);
+  outline-offset: -4px;
+}
+
 .post-index__marquee-track {
   display: flex;
   width: max-content;

--- a/themes/monoliquid/assets/css/screen.css
+++ b/themes/monoliquid/assets/css/screen.css
@@ -53,6 +53,10 @@
   box-sizing: border-box;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 html {
   background: var(--color-frame);
   color: var(--color-ink);
@@ -215,6 +219,15 @@ button:focus-visible {
   z-index: 10;
   border-bottom: 1px solid var(--color-frame);
   background: var(--color-canvas);
+}
+
+/* Ghost injects its own announcement app through ghost_head; this theme renders
+   the same data as a metal marquee in the header instead. */
+#ghost-announcement-bar,
+.gh-announcement-bar,
+[data-announcement-bar-root],
+iframe[src*="announcement-bar"] {
+  display: none !important;
 }
 
 .top-banner {
@@ -405,6 +418,7 @@ button:focus-visible {
   margin-top: 0;
 }
 
+.site-announcement-marquee,
 .post-index__marquee {
   width: 100%;
   margin-right: 0;
@@ -424,6 +438,7 @@ button:focus-visible {
   animation: marquee-latest 16s linear infinite;
 }
 
+.site-announcement-marquee span,
 .post-index__marquee span {
   display: inline-block;
   flex: 0 0 auto;

--- a/themes/monoliquid/assets/js/announcement-marquee.js
+++ b/themes/monoliquid/assets/js/announcement-marquee.js
@@ -1,0 +1,39 @@
+(function () {
+  var root = document.querySelector('[data-site-announcement-marquee]');
+  var track = document.querySelector('[data-site-announcement-track]');
+
+  if (!root || !track || !window.fetch) {
+    return;
+  }
+
+  fetch('/members/api/announcement/', {
+    headers: {
+      Accept: 'application/json'
+    }
+  })
+    .then(function (response) {
+      return response.ok ? response.json() : null;
+    })
+    .then(function (payload) {
+      var announcement = payload && payload.announcement && payload.announcement[0];
+      var text = announcement && announcement.announcement;
+
+      if (!text || !text.trim()) {
+        return;
+      }
+
+      track.textContent = '';
+
+      for (var index = 0; index < 12; index += 1) {
+        var item = document.createElement('span');
+        item.textContent = text.trim();
+        track.appendChild(item);
+      }
+
+      root.setAttribute('aria-label', text.trim());
+      root.hidden = false;
+    })
+    .catch(function () {
+      root.hidden = true;
+    });
+})();

--- a/themes/monoliquid/assets/js/announcement-marquee.js
+++ b/themes/monoliquid/assets/js/announcement-marquee.js
@@ -6,6 +6,28 @@
     return;
   }
 
+  function storageKey(text) {
+    return 'monoliquid:announcement-dismissed:' + encodeURIComponent(text);
+  }
+
+  function isDismissed(text) {
+    try {
+      return window.localStorage.getItem(storageKey(text)) === 'true';
+    } catch (error) {
+      return false;
+    }
+  }
+
+  function dismiss(text) {
+    root.hidden = true;
+
+    try {
+      window.localStorage.setItem(storageKey(text), 'true');
+    } catch (error) {
+      return;
+    }
+  }
+
   fetch('/members/api/announcement/', {
     headers: {
       Accept: 'application/json'
@@ -22,16 +44,35 @@
         return;
       }
 
+      text = text.trim();
+
+      if (isDismissed(text)) {
+        return;
+      }
+
       track.textContent = '';
 
       for (var index = 0; index < 12; index += 1) {
         var item = document.createElement('span');
-        item.textContent = text.trim();
+        item.textContent = text;
         track.appendChild(item);
       }
 
-      root.setAttribute('aria-label', text.trim());
+      root.setAttribute('aria-label', text);
+      root.setAttribute('role', 'button');
+      root.setAttribute('tabindex', '0');
       root.hidden = false;
+
+      root.addEventListener('click', function () {
+        dismiss(text);
+      });
+
+      root.addEventListener('keydown', function (event) {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          dismiss(text);
+        }
+      });
     })
     .catch(function () {
       root.hidden = true;

--- a/themes/monoliquid/default.hbs
+++ b/themes/monoliquid/default.hbs
@@ -15,6 +15,7 @@
         {{{body}}}
         {{> "site-footer"}}
     </div>
+    <script defer src="{{asset "js/announcement-marquee.js"}}"></script>
     {{ghost_foot}}
 </body>
 </html>

--- a/themes/monoliquid/partials/site-header.hbs
+++ b/themes/monoliquid/partials/site-header.hbs
@@ -9,6 +9,11 @@
         </a>
     </div>
 
+    <div class="site-announcement-marquee" data-site-announcement-marquee hidden aria-label="Announcement">
+        <div class="post-index__marquee-track" data-site-announcement-track aria-hidden="true">
+        </div>
+    </div>
+
     <nav class="site-nav" aria-label="Main navigation">
         {{navigation}}
     </nav>


### PR DESCRIPTION
## Summary
- Add a header announcement marquee above the main navigation
- Populate the marquee from Ghost’s `/members/api/announcement/` endpoint so it follows the Ghost Admin announcement setting
- Reuse the existing Latest marquee metal-pattern styling
- Hide Ghost’s default announcement app defensively so the custom marquee is the visible announcement treatment

## Verification
- Ran local Ghost with the writable theme override
- Set local announcement test content to `Problems Before Technology`
- Confirmed `/members/api/announcement/` returns the announcement
- Confirmed local HTML places `.site-announcement-marquee` immediately before `.site-nav`
- Opened `http://localhost:2368/` in cmux `surface:25` and verified the announcement repeats above HOME / ABOUT