### PR TITLE
fix: tuck nav under header on scroll

### DIFF
--- a/themes/monoliquid/assets/css/screen.css
+++ b/themes/monoliquid/assets/css/screen.css
@@ -217,6 +217,7 @@ button:focus-visible {
   position: sticky;
   top: 0;
   z-index: 10;
+  overflow: clip;
   border-bottom: 1px solid var(--color-frame);
   background: var(--color-canvas);
 }
@@ -231,6 +232,8 @@ iframe[src*="announcement-bar"] {
 }
 
 .top-banner {
+  position: relative;
+  z-index: 3;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
@@ -320,13 +323,14 @@ iframe[src*="announcement-bar"] {
 }
 
 .site-nav {
+  position: relative;
+  z-index: 1;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0;
   max-height: 36px;
   padding: 0 12px;
-  overflow: hidden;
   background: var(--color-paper);
   transform: translateY(0);
   transition:
@@ -337,7 +341,7 @@ iframe[src*="announcement-bar"] {
 
 .site-header--nav-hidden .site-nav {
   max-height: 0;
-  transform: translateY(-100%);
+  transform: translateY(calc(-100% - 1px));
 }
 
 .nav {
@@ -1238,6 +1242,20 @@ iframe[src*="announcement-bar"] {
     display: flex;
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .post-card.newsletter-card .newsletter-card__body {
+    align-items: stretch;
+    text-align: left;
+  }
+
+  .post-card.newsletter-card .post-card__copy,
+  .post-card.newsletter-card .newsletter-card__cta {
+    width: 100%;
+  }
+
+  .post-card.newsletter-card .newsletter-card__cta {
+    min-height: 44px;
   }
 
   .post-card__media {

--- a/themes/monoliquid/assets/css/screen.css
+++ b/themes/monoliquid/assets/css/screen.css
@@ -240,6 +240,9 @@ iframe[src*="announcement-bar"] {
   border-bottom: 1px solid var(--color-frame);
   background: var(--color-frame);
   color: var(--color-canvas);
+  transition:
+    min-height 180ms var(--ease-out),
+    padding 180ms var(--ease-out);
 }
 
 .site-brand {
@@ -253,12 +256,14 @@ iframe[src*="announcement-bar"] {
   line-height: 1;
   text-transform: uppercase;
   text-wrap: balance;
+  transition: font-size 180ms var(--ease-out);
 }
 
 .site-brand img {
   width: auto;
   max-height: 32px;
   filter: invert(1) grayscale(1) contrast(1.2);
+  transition: max-height 180ms var(--ease-out);
 }
 
 .top-banner__line {
@@ -270,6 +275,24 @@ iframe[src*="announcement-bar"] {
   text-align: right;
   text-transform: uppercase;
   white-space: nowrap;
+  transition: font-size 180ms var(--ease-out);
+}
+
+.site-header--compact .top-banner {
+  min-height: 34px;
+  padding: calc(6px + env(safe-area-inset-top)) 14px 6px;
+}
+
+.site-header--compact .site-brand {
+  font-size: 14px;
+}
+
+.site-header--compact .site-brand img {
+  max-height: 16px;
+}
+
+.site-header--compact .top-banner__line {
+  font-size: 10px;
 }
 
 .new-sticker {
@@ -301,8 +324,20 @@ iframe[src*="announcement-bar"] {
   align-items: center;
   justify-content: space-between;
   gap: 0;
+  max-height: 36px;
   padding: 0 12px;
+  overflow: hidden;
   background: var(--color-paper);
+  transform: translateY(0);
+  transition:
+    max-height 180ms var(--ease-out),
+    transform 180ms var(--ease-out);
+  will-change: max-height, transform;
+}
+
+.site-header--nav-hidden .site-nav {
+  max-height: 0;
+  transform: translateY(-100%);
 }
 
 .nav {

--- a/themes/monoliquid/assets/js/site-header.js
+++ b/themes/monoliquid/assets/js/site-header.js
@@ -1,0 +1,38 @@
+(function () {
+  var header = document.querySelector('.site-header');
+
+  if (!header) {
+    return;
+  }
+
+  var lastY = window.scrollY || 0;
+  var ticking = false;
+
+  function updateHeader() {
+    var currentY = Math.max(window.scrollY || 0, 0);
+    var delta = currentY - lastY;
+
+    header.classList.toggle('site-header--compact', currentY > 24);
+
+    if (currentY <= 8 || delta < -4) {
+      header.classList.remove('site-header--nav-hidden');
+    } else if (currentY > 80 && delta > 4) {
+      header.classList.add('site-header--nav-hidden');
+    }
+
+    lastY = currentY;
+    ticking = false;
+  }
+
+  function requestUpdate() {
+    if (ticking) {
+      return;
+    }
+
+    ticking = true;
+    window.requestAnimationFrame(updateHeader);
+  }
+
+  updateHeader();
+  window.addEventListener('scroll', requestUpdate, {passive: true});
+})();

--- a/themes/monoliquid/default.hbs
+++ b/themes/monoliquid/default.hbs
@@ -16,6 +16,7 @@
         {{> "site-footer"}}
     </div>
     <script defer src="{{asset "js/announcement-marquee.js"}}"></script>
+    <script defer src="{{asset "js/site-header.js"}}"></script>
     {{ghost_foot}}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- tuck the nav behind the top banner on downward scroll using z-index and translate
- keep the compact sticky header behavior while restoring nav on upward scroll
- align the in-list newsletter card left on mobile and stretch its Subscribe control full width

## Verification
- git diff --check
- local Ghost assets served from http://127.0.0.1:2368
- cmux browser: confirmed nav hides on scroll down and returns on scroll up