### PR TITLE
fix: smooth sticky nav behavior

### DIFF
--- a/themes/monoliquid/assets/css/screen.css
+++ b/themes/monoliquid/assets/css/screen.css
@@ -244,8 +244,8 @@ iframe[src*="announcement-bar"] {
   background: var(--color-frame);
   color: var(--color-canvas);
   transition:
-    min-height 180ms var(--ease-out),
-    padding 180ms var(--ease-out);
+    min-height 240ms var(--ease-out),
+    padding 240ms var(--ease-out);
 }
 
 .site-brand {
@@ -259,14 +259,14 @@ iframe[src*="announcement-bar"] {
   line-height: 1;
   text-transform: uppercase;
   text-wrap: balance;
-  transition: font-size 180ms var(--ease-out);
+  transition: font-size 240ms var(--ease-out);
 }
 
 .site-brand img {
   width: auto;
   max-height: 32px;
   filter: invert(1) grayscale(1) contrast(1.2);
-  transition: max-height 180ms var(--ease-out);
+  transition: max-height 240ms var(--ease-out);
 }
 
 .top-banner__line {
@@ -278,7 +278,7 @@ iframe[src*="announcement-bar"] {
   text-align: right;
   text-transform: uppercase;
   white-space: nowrap;
-  transition: font-size 180ms var(--ease-out);
+  transition: font-size 240ms var(--ease-out);
 }
 
 .site-header--compact .top-banner {
@@ -334,8 +334,8 @@ iframe[src*="announcement-bar"] {
   background: var(--color-paper);
   transform: translateY(0);
   transition:
-    max-height 180ms var(--ease-out),
-    transform 180ms var(--ease-out);
+    max-height 320ms var(--ease-out),
+    transform 320ms var(--ease-out);
   will-change: max-height, transform;
 }
 
@@ -538,6 +538,8 @@ iframe[src*="announcement-bar"] {
 }
 
 .site-announcement-marquee {
+  position: relative;
+  z-index: 2;
   cursor: pointer;
 }
 

--- a/themes/monoliquid/assets/js/site-header.js
+++ b/themes/monoliquid/assets/js/site-header.js
@@ -5,8 +5,25 @@
     return;
   }
 
-  var lastY = window.scrollY || 0;
+  var lastY = Math.max(window.scrollY || 0, 0);
+  var navHidden = header.classList.contains('site-header--nav-hidden');
+  var scrollIntent = 0;
   var ticking = false;
+  var hideStartY = 96;
+  var hideDistance = 42;
+  var revealDistance = 56;
+  var topRevealY = 16;
+  var ignoreDelta = 2;
+
+  function setNavHidden(nextHidden) {
+    if (navHidden === nextHidden) {
+      return;
+    }
+
+    navHidden = nextHidden;
+    scrollIntent = 0;
+    header.classList.toggle('site-header--nav-hidden', navHidden);
+  }
 
   function updateHeader() {
     var currentY = Math.max(window.scrollY || 0, 0);
@@ -14,10 +31,32 @@
 
     header.classList.toggle('site-header--compact', currentY > 24);
 
-    if (currentY <= 8 || delta < -4) {
-      header.classList.remove('site-header--nav-hidden');
-    } else if (currentY > 80 && delta > 4) {
-      header.classList.add('site-header--nav-hidden');
+    if (currentY <= topRevealY) {
+      setNavHidden(false);
+      lastY = currentY;
+      ticking = false;
+      return;
+    }
+
+    if (Math.abs(delta) <= ignoreDelta) {
+      lastY = currentY;
+      ticking = false;
+      return;
+    }
+
+    if (
+      (delta > 0 && scrollIntent < 0) ||
+      (delta < 0 && scrollIntent > 0)
+    ) {
+      scrollIntent = 0;
+    }
+
+    scrollIntent += delta;
+
+    if (!navHidden && currentY > hideStartY && scrollIntent >= hideDistance) {
+      setNavHidden(true);
+    } else if (navHidden && scrollIntent <= -revealDistance) {
+      setNavHidden(false);
     }
 
     lastY = currentY;


### PR DESCRIPTION
## Summary
- slow down sticky header and nav transitions
- add scroll-intent hysteresis so the nav does not rapidly toggle near scroll boundaries
- layer the announcement marquee above the sliding nav and below the top banner

## Verification
- git diff --check