### PR TITLE
Harden Ghost release and deployment boundaries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: write
     outputs:
@@ -26,19 +27,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.18.0
 
       - name: Enable corepack & pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@10 --activate
+          corepack prepare pnpm@10.13.1 --activate
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Test deployment safeguards
         run: ./scripts/check-deploy-workflow.sh
@@ -62,6 +64,7 @@ jobs:
   deploy:
     runs-on: self-hosted
     needs: release
+    if: github.ref == 'refs/heads/main'
     environment: production
     permissions: {}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      deploy_sha: ${{ steps.deploy-revision.outputs.sha }}
 
     steps:
       - name: Checkout
@@ -47,6 +49,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm semantic-release
 
+      - name: Resolve deployed main revision
+        id: deploy-revision
+        shell: bash
+        run: |
+          set -euo pipefail
+          remote_line="$(git ls-remote --exit-code origin refs/heads/main)"
+          deploy_sha="${remote_line%%$'\t'*}"
+          [[ "${deploy_sha}" =~ ^[0-9a-f]{40}$ ]]
+          printf 'sha=%s\n' "${deploy_sha}" >> "${GITHUB_OUTPUT}"
+
   deploy:
     runs-on: self-hosted
     needs: release
@@ -56,5 +68,5 @@ jobs:
     steps:
       - name: Deploy verified main revision
         env:
-          DEPLOY_SHA: ${{ github.sha }}
+          DEPLOY_SHA: ${{ needs.release.outputs.deploy_sha }}
         run: sudo /usr/local/sbin/deploy-ghost-blog "$DEPLOY_SHA"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,13 +24,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24.18.0
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,12 +7,17 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
+
+concurrency:
+  group: ghost-production
+  cancel-in-progress: false
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
@@ -33,39 +38,23 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Test deployment safeguards
+        run: ./scripts/check-deploy-workflow.sh
+
       - name: Semantic Release
         id: semrel
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          pnpm semantic-release || echo "NO_RELEASE=true" >> $GITHUB_ENV
+        run: pnpm semantic-release
 
   deploy:
     runs-on: self-hosted
     needs: release
+    environment: production
+    permissions: {}
 
     steps:
-      - name: Checkout deploy assets
-        uses: actions/checkout@v4
-
-      - name: Import SOPS age key from Vault
-        uses: hashicorp/vault-action@v3
-        with:
-          url: https://vault.dohyeon.kr
-          method: jwt
-          path: jwt
-          role: dohyeon-kr-deploy
-          jwtGithubAudience: vault.dohyeon.kr
-          secrets: |
-            kv/data/sops/dohyeon-kr age_key | SOPS_AGE_KEY
-
-      - name: Decrypt env file
-        run: |
-          sops -d --input-type dotenv --output-type dotenv secrets/prod/ghost.env.enc > .env
-          chmod 600 .env
-
-      - name: Prepare wrapper inputs
-        run: cp secrets/prod/ghost.env.enc secrets/ghost.env.enc
-
-      - name: Deploy Ghost
-        run: sudo /usr/local/sbin/deploy-ghost-blog "$GITHUB_WORKSPACE"
+      - name: Deploy verified main revision
+        env:
+          DEPLOY_SHA: ${{ github.sha }}
+        run: sudo /usr/local/sbin/deploy-ghost-blog "$DEPLOY_SHA"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -10,7 +10,7 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run gitleaks
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ content/
 
 # Plaintext secret files. Commit only SOPS-encrypted *.env.enc files.
 secrets/*.env
+secrets/**/*.env
 .age.key
 *.agekey
 *.decrypted.*

--- a/README.md
+++ b/README.md
@@ -159,14 +159,37 @@ Push to `main` or run the `Release & Deploy Ghost` workflow manually.
 The workflow:
 
 1. runs semantic-release
-2. authenticates to Vault with GitHub OIDC
-3. reads the SOPS age private key from `kv/sops/dohyeon-kr`
-4. decrypts `secrets/prod/ghost.env.enc` to a workspace `.env`
-5. runs the restricted deployment wrapper:
+2. enters the protected GitHub `production` environment
+3. passes only the triggering 40-character commit SHA to the restricted deployment wrapper:
 
 ```sh
-sudo /usr/local/sbin/deploy-ghost-blog "$GITHUB_WORKSPACE"
+sudo /usr/local/sbin/deploy-ghost-blog "$DEPLOY_SHA"
 ```
+
+The self-hosted job has no repository or OIDC permissions and does not check out
+the repository, contact Vault, run SOPS, or provide its workspace to root. The
+root-owned wrapper independently verifies that the SHA is the public
+`dohyeon-kr/dohyeon.kr` `main` HEAD over HTTPS, downloads that exact GitHub
+archive into a private root temporary directory, and installs only the validated
+Compose file, nginx config, and theme. It reuses the existing root-owned
+`/var/www/ghost-blog/.env`; a missing, linked, non-root-owned, or overly
+permissive file aborts deployment.
+
+Before enabling the new wrapper on an existing host, move the two deployment
+asset directories out of the runner account's ownership. Do not recursively
+change the Ghost content directory:
+
+```sh
+sudo chown root:root /var/www/ghost-blog /var/www/ghost-blog/themes
+sudo chmod 755 /var/www/ghost-blog /var/www/ghost-blog/themes
+sudo test -f /var/www/ghost-blog/.env
+test "$(sudo stat -c %u /var/www/ghost-blog/.env)" = 0
+sudo chmod 600 /var/www/ghost-blog/.env
+```
+
+The sudoers entry for the self-hosted runner must keep environment resetting
+enabled and allow only `/usr/local/sbin/deploy-ghost-blog`; the wrapper itself
+rejects extra arguments and non-SHA input.
 
 `https://meetings.dohyeon.kr` is deployed outside this repository by the
 internal polling deploy agent. The agent watches
@@ -180,12 +203,7 @@ configuration deliberately instead of adding inline privileged commands to
 
 Docker registry credentials for future CI jobs should follow the
 `dohyeon-base` Vault OIDC example instead of GitHub repository secrets. This
-Ghost deployment does not currently need a Docker registry login step.
-
-The `dohyeon-base` standard path for new services is
-`kv/sops/<project>/<environment>`. This repository still reads the deploy key
-from `kv/sops/dohyeon-kr` because that is the Vault path currently granted to
-the `dohyeon-kr-deploy` GitHub OIDC role.
+Ghost deployment does not access Vault or need a Docker registry login step.
 
 Useful server commands:
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ The workflow:
 
 1. runs semantic-release
 2. enters the protected GitHub `production` environment
-3. passes only the triggering 40-character commit SHA to the restricted deployment wrapper:
+3. resolves the public `main` HEAD after semantic-release and passes only that
+   40-character commit SHA to the restricted deployment wrapper:
 
 ```sh
 sudo /usr/local/sbin/deploy-ghost-blog "$DEPLOY_SHA"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ theme files. Legacy static-site/runtime code has been removed.
 
 ## Stack
 
-- Ghost 5 Docker image
+- Ghost 5 Docker image selected by an exact local digest
 - SQLite content database for the initial setup
 - Nginx reverse proxy on `blog.dohyeon.kr`
 - Nginx redirect from `dohyeon.kr` to `blog.dohyeon.kr`
@@ -18,6 +18,8 @@ theme files. Legacy static-site/runtime code has been removed.
 
 ```sh
 cp .env.example .env
+docker pull ghost:5-alpine
+export GHOST_IMAGE="$(docker image inspect --format '{{index .RepoDigests 0}}' ghost:5-alpine)"
 docker compose up -d
 ```
 
@@ -45,6 +47,11 @@ The GitHub Actions workflow deploys these files to `/var/www/ghost-blog` on the
 
 `content/` is the persistent Ghost volume. It contains uploaded images, themes,
 logs, and the SQLite database at `content/data/ghost.db`.
+
+The server also has `/etc/ghost-blog/image.env`, a root-owned mode `0600` file
+containing exactly one `GHOST_IMAGE=ghost@sha256:<64 hex>` assignment. It is
+separate from the service `.env`, so deployment metadata is not injected into
+the Ghost process.
 
 
 ## Mail
@@ -174,7 +181,9 @@ root-owned wrapper independently verifies that the SHA is the public
 archive into a private root temporary directory, and installs only the validated
 Compose file, nginx config, and theme. It reuses the existing root-owned
 `/var/www/ghost-blog/.env`; a missing, linked, non-root-owned, or overly
-permissive file aborts deployment.
+permissive file aborts deployment. It also requires the exact digest in the
+root-owned `/etc/ghost-blog/image.env` to exist locally. The wrapper never pulls
+a mutable tag and waits for the digest-pinned container health check.
 
 Before enabling the new wrapper on an existing host, move the two deployment
 asset directories out of the runner account's ownership. Do not recursively
@@ -186,6 +195,11 @@ sudo chmod 755 /var/www/ghost-blog /var/www/ghost-blog/themes
 sudo test -f /var/www/ghost-blog/.env
 test "$(sudo stat -c %u /var/www/ghost-blog/.env)" = 0
 sudo chmod 600 /var/www/ghost-blog/.env
+sudo install -d -o root -g root -m 0755 /etc/ghost-blog
+# Populate image.env from the currently reviewed local Ghost image digest.
+sudo test -f /etc/ghost-blog/image.env
+test "$(sudo stat -c %u /etc/ghost-blog/image.env)" = 0
+sudo chmod 600 /etc/ghost-blog/image.env
 ```
 
 The sudoers entry for the self-hosted runner must keep environment resetting
@@ -211,8 +225,11 @@ Useful server commands:
 ```sh
 ssh dohyeon.kr 'cd /var/www/ghost-blog && docker compose ps'
 ssh dohyeon.kr 'cd /var/www/ghost-blog && docker compose logs -f ghost'
-ssh dohyeon.kr 'cd /var/www/ghost-blog && docker compose pull && docker compose up -d'
 ```
+
+Do not run an ad hoc server-side `docker compose pull`. Image updates require a
+reviewed digest in `/etc/ghost-blog/image.env`, an explicit backup, and a normal
+wrapper deployment of the current public `main` SHA.
 
 ## Nginx
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,19 @@
 services:
   ghost:
-    image: ghost:5-alpine
+    image: ${GHOST_IMAGE:?GHOST_IMAGE must be an exact digest reference}
+    pull_policy: never
     container_name: dohyeon-ghost
     restart: unless-stopped
+    init: true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - SETGID
+      - SETUID
+    security_opt:
+      - no-new-privileges:true
     ports:
       - "127.0.0.1:${GHOST_PORT:-2368}:2368"
     env_file:
@@ -19,3 +30,23 @@ services:
     volumes:
       - ${GHOST_CONTENT_DIR:-./content}:/var/lib/ghost/content
       - ./themes/monoliquid:/var/lib/ghost/content/themes/monoliquid
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - >-
+          require('http').get('http://127.0.0.1:2368/', (response) =>
+          process.exit(response.statusCode < 500 ? 0 : 1))
+          .on('error', () => process.exit(1))
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 1m
+    stop_grace_period: 1m
+    logging:
+      driver: json-file
+      options:
+        max-size: 20m
+        max-file: "5"
+        compress: "true"

--- a/scripts/check-deploy-workflow.sh
+++ b/scripts/check-deploy-workflow.sh
@@ -9,6 +9,11 @@ deploy_job="$(sed -n '/^  deploy:/,$p' "$workflow")"
 grep -Fq "  group: ghost-production" "$workflow"
 grep -Fq "  cancel-in-progress: false" "$workflow"
 grep -Fq "permissions:" "$workflow"
+[[ "$(grep -Fc "    if: github.ref == 'refs/heads/main'" "$workflow")" == 2 ]]
+grep -Fq "          persist-credentials: false" "$workflow"
+grep -Fq "          node-version: 24.18.0" "$workflow"
+grep -Fq "          corepack prepare pnpm@10.13.1 --activate" "$workflow"
+grep -Fq "        run: pnpm install --frozen-lockfile --ignore-scripts" "$workflow"
 grep -Fq "      contents: write" "$workflow"
 if grep -Eq '^  (contents: write|id-token: write)$' "$workflow"; then
   echo "Write and OIDC permissions must be scoped to the job that needs them." >&2

--- a/scripts/check-deploy-workflow.sh
+++ b/scripts/check-deploy-workflow.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 workflow="$repo_root/.github/workflows/deploy.yml"
+compose="$repo_root/docker-compose.yml"
 deploy_job="$(sed -n '/^  deploy:/,$p' "$workflow")"
 
 grep -Fq "  group: ghost-production" "$workflow"
@@ -37,5 +38,17 @@ fi
 if [[ "$(grep -Ec '^      - name:' <<<"$deploy_job")" != 1 ]] || \
   [[ "$(grep -Ec '^        run:' <<<"$deploy_job")" != 1 ]]; then
   echo "The self-hosted deploy job must contain only the SHA deployment step." >&2
+  exit 1
+fi
+
+grep -Fq '    image: ${GHOST_IMAGE:?GHOST_IMAGE must be an exact digest reference}' "$compose"
+grep -Fq '    pull_policy: never' "$compose"
+grep -Fq '      - no-new-privileges:true' "$compose"
+grep -Fq '      - ALL' "$compose"
+grep -Fq '    healthcheck:' "$compose"
+grep -Fq '    logging:' "$compose"
+
+if grep -Eq '^[[:space:]]+image:[[:space:]]+ghost:[^[:space:]]+' "$compose"; then
+  echo "The production Compose file must not use a mutable Ghost tag." >&2
   exit 1
 fi

--- a/scripts/check-deploy-workflow.sh
+++ b/scripts/check-deploy-workflow.sh
@@ -18,12 +18,15 @@ if grep -Eq 'semantic-release.*\|\|' "$workflow"; then
   echo "Semantic Release failures must stop deployment." >&2
   exit 1
 fi
+grep -Fq '      deploy_sha: ${{ steps.deploy-revision.outputs.sha }}' "$workflow"
+grep -Fq '          remote_line="$(git ls-remote --exit-code origin refs/heads/main)"' "$workflow"
+grep -Fq '          printf '\''sha=%s\n'\'' "${deploy_sha}" >> "${GITHUB_OUTPUT}"' "$workflow"
 
 grep -Fq "    runs-on: self-hosted" <<<"$deploy_job"
 grep -Fq "    needs: release" <<<"$deploy_job"
 grep -Fq "    environment: production" <<<"$deploy_job"
 grep -Fq "    permissions: {}" <<<"$deploy_job"
-grep -Fq '          DEPLOY_SHA: ${{ github.sha }}' <<<"$deploy_job"
+grep -Fq '          DEPLOY_SHA: ${{ needs.release.outputs.deploy_sha }}' <<<"$deploy_job"
 grep -Fxq '        run: sudo /usr/local/sbin/deploy-ghost-blog "$DEPLOY_SHA"' <<<"$deploy_job"
 
 if grep -Eqi '^[[:space:]]+uses:|actions/checkout|vault-action|sops|GITHUB_WORKSPACE|id-token|contents:|\$\{\{[[:space:]]*(secrets|vars)\.' <<<"$deploy_job"; then

--- a/scripts/check-deploy-workflow.sh
+++ b/scripts/check-deploy-workflow.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+workflow="$repo_root/.github/workflows/deploy.yml"
+deploy_job="$(sed -n '/^  deploy:/,$p' "$workflow")"
+
+grep -Fq "  group: ghost-production" "$workflow"
+grep -Fq "  cancel-in-progress: false" "$workflow"
+grep -Fq "permissions:" "$workflow"
+grep -Fq "      contents: write" "$workflow"
+if grep -Eq '^  (contents: write|id-token: write)$' "$workflow"; then
+  echo "Write and OIDC permissions must be scoped to the job that needs them." >&2
+  exit 1
+fi
+grep -Fxq "        run: pnpm semantic-release" "$workflow"
+if grep -Eq 'semantic-release.*\|\|' "$workflow"; then
+  echo "Semantic Release failures must stop deployment." >&2
+  exit 1
+fi
+
+grep -Fq "    runs-on: self-hosted" <<<"$deploy_job"
+grep -Fq "    needs: release" <<<"$deploy_job"
+grep -Fq "    environment: production" <<<"$deploy_job"
+grep -Fq "    permissions: {}" <<<"$deploy_job"
+grep -Fq '          DEPLOY_SHA: ${{ github.sha }}' <<<"$deploy_job"
+grep -Fxq '        run: sudo /usr/local/sbin/deploy-ghost-blog "$DEPLOY_SHA"' <<<"$deploy_job"
+
+if grep -Eqi '^[[:space:]]+uses:|actions/checkout|vault-action|sops|GITHUB_WORKSPACE|id-token|contents:|\$\{\{[[:space:]]*(secrets|vars)\.' <<<"$deploy_job"; then
+  echo "The self-hosted deploy job may pass only github.sha to the root wrapper." >&2
+  exit 1
+fi
+
+if [[ "$(grep -Ec '^      - name:' <<<"$deploy_job")" != 1 ]] || \
+  [[ "$(grep -Ec '^        run:' <<<"$deploy_job")" != 1 ]]; then
+  echo "The self-hosted deploy job must contain only the SHA deployment step." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- remove persisted deployment credentials and deploy the reviewed main revision
- pin the Ghost runtime image and constrain release workflow trust
- pin all GitHub Actions by commit and enable action updates

## Verification
- deploy workflow contract checks
- Compose and Ghost wrapper validation
- workflow YAML and action pin audit

## Operational note
Merging pushes main through the production deployment workflow. Keep this PR open until the reviewed Ghost wrapper and image prerequisites are confirmed live.